### PR TITLE
Add notification controls: per-vehicle unsubscribe, snooze, and mute

### DIFF
--- a/api/app/controllers/v2/prompt_controls_controller.rb
+++ b/api/app/controllers/v2/prompt_controls_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module V2
+  class PromptControlsController < ApplicationController
+    skip_before_action :authenticate
+
+    def remind_me_later
+      vehicle = find_vehicle
+      vehicle.update!(prompt_snoozed_until: 1.month.from_now)
+
+      render plain: 'Reminders snoozed for one month.'
+    rescue NotificationToken::InvalidTokenError, ActiveRecord::RecordNotFound
+      render plain: 'This link is invalid or has expired.', status: :not_found
+    end
+
+    def mute
+      vehicle = find_vehicle
+      prefs = vehicle.preferences
+      prefs.send_prompt_for_records = false
+      vehicle.preferences = prefs
+      vehicle.save!
+
+      render plain: 'Prompt emails have been muted for this vehicle.'
+    rescue NotificationToken::InvalidTokenError, ActiveRecord::RecordNotFound
+      render plain: 'This link is invalid or has expired.', status: :not_found
+    end
+
+    private
+
+    def find_vehicle
+      payload = NotificationToken.verify(params[:token])
+      vehicle_id = payload['vehicle_id'] || payload[:vehicle_id]
+      Vehicle.find(vehicle_id)
+    end
+  end
+end

--- a/api/app/controllers/v2/unsubscribes_controller.rb
+++ b/api/app/controllers/v2/unsubscribes_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module V2
+  class UnsubscribesController < ApplicationController
+    skip_before_action :authenticate
+
+    def show
+      payload = NotificationToken.verify(params[:token])
+      vehicle = Vehicle.find(payload['vehicle_id'])
+
+      action = payload['action'] || payload[:action]
+      prefs = vehicle.preferences
+
+      case action
+      when 'prompt'
+        prefs.send_prompt_for_records = false
+      when 'reminders'
+        prefs.send_reminder_emails = false
+      end
+
+      vehicle.preferences = prefs
+      vehicle.save!
+
+      render plain: 'You have been unsubscribed.'
+    rescue NotificationToken::InvalidTokenError, ActiveRecord::RecordNotFound
+      render plain: 'This link is invalid or has expired.', status: :not_found
+    end
+  end
+end

--- a/api/app/controllers/v2/vehicles_controller.rb
+++ b/api/app/controllers/v2/vehicles_controller.rb
@@ -75,7 +75,7 @@ module V2
         .require(:vehicle)
         .permit(
           :name, :vin, :notes, :position, :enable_cost, :distance_unit,
-          :retired, :import_file, :fuelly, :color,
+          :retired, :import_file, :fuelly, :color, :prompt_snoozed_until,
           preferences: %i[
             enable_sharing
             enable_cost

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -5,4 +5,52 @@ class ApplicationMailer < ActionMailer::Base
 
   default from: 'spanner@nicinabox.com'
   layout 'mailer'
+
+  helper_method :logo_data_uri
+  helper_method :unsubscribe_url
+  helper_method :prompt_control_url
+
+  def logo_data_uri
+    return @logo_data_uri if defined?(@logo_data_uri)
+
+    path = Rails.root.join('public/images/email-logo.png')
+    data = path.read
+    encoded = Base64.strict_encode64(data)
+
+    @logo_data_uri = "data:image/png;base64,#{encoded}"
+  end
+
+  def unsubscribe_url(vehicle, action: :reminders)
+    token = NotificationToken.generate(
+      vehicle_id: vehicle.id,
+      action: action.to_s
+    )
+
+    routes.unsubscribe_url(token: token)
+  end
+
+  def prompt_control_url(vehicle, action:)
+    token = NotificationToken.generate(
+      vehicle_id: vehicle.id,
+      action: action.to_s
+    )
+
+    case action.to_sym
+    when :remind_me_later
+      routes.remind_me_later_url(token: token)
+    when :mute
+      routes.mute_prompt_url(token: token)
+    end
+  end
+
+  private
+
+  def routes
+    Rails.application.routes.default_url_options = default_url_options
+    Rails.application.routes.url_helpers
+  end
+
+  def default_url_options
+    ActionMailer::Base.default_url_options
+  end
 end

--- a/api/app/mailers/prompt_user_mailer.rb
+++ b/api/app/mailers/prompt_user_mailer.rb
@@ -4,6 +4,9 @@ class PromptUserMailer < ApplicationMailer
   def add_record(user, vehicle)
     @user = user
     @vehicle = vehicle
+    @unsubscribe_url = unsubscribe_url(@vehicle, action: :prompt)
+    @remind_me_later_url = prompt_control_url(@vehicle, action: :remind_me_later)
+    @mute_url = prompt_control_url(@vehicle, action: :mute)
 
     mail to: @user.email,
          subject: "Have you done anything to your #{vehicle.name} lately?"

--- a/api/app/mailers/reminders_mailer.rb
+++ b/api/app/mailers/reminders_mailer.rb
@@ -4,6 +4,8 @@ class RemindersMailer < ApplicationMailer
   def reminder_today(user, reminders)
     @user      = user
     @reminders = reminders
+    @vehicle   = @reminders.first.vehicle
+    @unsubscribe_url = unsubscribe_url(@vehicle, action: :reminders)
 
     mail to: @user.email, subject: reminder_subject(reminders)
   end
@@ -12,6 +14,8 @@ class RemindersMailer < ApplicationMailer
     @user      = user
     @reminders = reminders
     @date      = @reminders.first.try(:reminder_date) || @reminders.first.try(:date) || Time.zone.today
+    @vehicle   = @reminders.first.vehicle
+    @unsubscribe_url = unsubscribe_url(@vehicle, action: :reminders)
 
     mail to: @user.email, subject: reminder_subject(reminders)
   end

--- a/api/app/models/vehicle.rb
+++ b/api/app/models/vehicle.rb
@@ -15,14 +15,13 @@ class Vehicle < ApplicationRecord
   WEIGHT_COEFFICIENT = 10
 
   def preferences
-    @preferences ||= VehiclePreferences.new(self[:preferences] || {})
+    VehiclePreferences.new(self[:preferences] || {})
   end
 
   def preferences=(value)
     # Accepts either a VehiclePreferences object or a hash
     prefs_hash = value.is_a?(VehiclePreferences) ? value.to_hash : value
     self[:preferences] = prefs_hash
-    @preferences = VehiclePreferences.new(prefs_hash)
   end
 
   def prompt_for_first_record!
@@ -33,11 +32,16 @@ class Vehicle < ApplicationRecord
 
   def prompt_for_new_record!
     return unless preferences.send_prompt_for_records
+    return if prompt_snoozed? && prompt_snoozed_until > Time.zone.now
 
     date = estimated_next_record_date
     return unless date && (date <= Time.zone.today.beginning_of_day)
 
     PromptUserMailer.add_record(user, self).deliver_later
+  end
+
+  def prompt_snoozed?
+    prompt_snoozed_until.present?
   end
 
   def squish_vin

--- a/api/app/serializers/vehicle_serializer.rb
+++ b/api/app/serializers/vehicle_serializer.rb
@@ -3,5 +3,5 @@
 class VehicleSerializer < ActiveModel::Serializer
   attributes :id, :name, :vin, :notes, :position, :enable_cost, :distance_unit,
              :retired, :created_at, :miles_per_day, :miles_per_year, :estimated_mileage,
-             :squish_vin, :reminders, :color, :preferences
+             :squish_vin, :reminders, :color, :preferences, :prompt_snoozed_until
 end

--- a/api/app/services/notification_token.rb
+++ b/api/app/services/notification_token.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class NotificationToken
+  class InvalidTokenError < StandardError; end
+
+  TOKEN_VERIFIER = 'notification_controls'
+  DEFAULT_EXPIRES_IN = 30.days
+
+  def self.generate(vehicle_id:, action:)
+    new(vehicle_id: vehicle_id, action: action).generate
+  end
+
+  def self.verify(token)
+    new(token: token).verify
+  end
+
+  def initialize(vehicle_id: nil, action: nil, token: nil)
+    @vehicle_id = vehicle_id
+    @action = action
+    @token = token
+  end
+
+  def generate
+    message = {
+      vehicle_id: @vehicle_id,
+      action: @action,
+      expires_at: DEFAULT_EXPIRES_IN.from_now.to_i
+    }
+
+    verifier.generate(message)
+  end
+
+  def verify
+    payload = verifier.verify(@token)
+    raise InvalidTokenError, 'Invalid token' unless payload
+
+    expires_at = payload['expires_at'] || payload[:expires_at]
+    raise InvalidTokenError, 'Invalid token' unless expires_at
+
+    if Time.at(expires_at) < Time.now
+      raise InvalidTokenError, 'Token expired'
+    end
+
+    payload.with_indifferent_access
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    raise InvalidTokenError, 'Invalid token'
+  end
+
+  private
+
+  def verifier
+    Rails.application.message_verifier(TOKEN_VERIFIER)
+  end
+end

--- a/api/app/services/vehicle_preferences.rb
+++ b/api/app/services/vehicle_preferences.rb
@@ -9,6 +9,10 @@ class VehiclePreferences
   attribute :send_prompt_for_records, Boolean, default: true
   attribute :show_mileage_adjustment_records, Boolean, default: true
 
+  def to_hash
+    attributes.transform_values { |v| v.is_a?(Symbol) ? v.to_s : v }
+  end
+
   def self.dump(preferences)
     preferences.to_hash
   end

--- a/api/app/views/layouts/mailer.html.erb
+++ b/api/app/views/layouts/mailer.html.erb
@@ -24,6 +24,13 @@
             View all your vehicles at
             <a class="text-muted" href="https://spanner.nicinabox.com">https://spanner.nicinabox.com</a>
           </small>
+          <% if @unsubscribe_url %>
+            <div>
+              <small class="text-muted">
+                <a class="text-muted" href="<%= @unsubscribe_url %>">Unsubscribe</a>
+              </small>
+            </div>
+          <% end %>
           <div>
             <small class="text-muted">
               Thanks for using Spanner!

--- a/api/app/views/layouts/mailer.text.erb
+++ b/api/app/views/layouts/mailer.text.erb
@@ -5,3 +5,7 @@ Hello <%= @user.email %>!
 <%end %>
 
 <%= yield %>
+
+<% if @unsubscribe_url %>
+Unsubscribe: <%= @unsubscribe_url %>
+<% end %>

--- a/api/app/views/prompt_user_mailer/add_record.html.erb
+++ b/api/app/views/prompt_user_mailer/add_record.html.erb
@@ -4,3 +4,7 @@
 <p>
   <%= link_to 'Add Service', vehicle_url(@vehicle), class: 'button' %>
 </p>
+<p>
+  <%= link_to 'Remind Me Later', @remind_me_later_url, class: 'button button-small' %>
+  <%= link_to 'Mute', @mute_url, class: 'button button-small' %>
+</p>

--- a/api/app/views/prompt_user_mailer/add_record.text.erb
+++ b/api/app/views/prompt_user_mailer/add_record.text.erb
@@ -1,3 +1,5 @@
 We noticed it's about time for service on your <%= @vehicle.name %>. Have you done any maintenance or modifications recently?
 
 Add service: <%= vehicle_url(@vehicle) %>
+Remind Me Later: <%= @remind_me_later_url %>
+Mute: <%= @mute_url %>

--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -27,6 +27,10 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
+
+  config.action_mailer.default_url_options = {
+    host: 'localhost:3000'
+  }
   config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
@@ -36,10 +40,6 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
-
-  config.action_mailer.default_url_options = {
-    host: 'http://localhost:3000'
-  }
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -7,6 +7,10 @@ Rails.application.routes.draw do
     post 'sessions', to: 'sessions#create'
 
     get 'login(/:login_token)', to: 'sessions#login', as: 'login'
+
+    get 'unsubscribe/:token', to: 'unsubscribes#show', as: 'unsubscribe'
+    post 'prompt_controls/:token/remind_me_later', to: 'prompt_controls#remind_me_later', as: 'remind_me_later'
+    post 'prompt_controls/:token/mute', to: 'prompt_controls#mute', as: 'mute_prompt'
   end
 
   scope module: :v2, constraints: ApiConstraint.new(version: 2) do

--- a/api/db/migrate/20260613140000_add_prompt_snoozed_until_to_vehicles.rb
+++ b/api/db/migrate/20260613140000_add_prompt_snoozed_until_to_vehicles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPromptSnoozedUntilToVehicles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :vehicles, :prompt_snoozed_until, :datetime
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -93,6 +93,7 @@ ActiveRecord::Schema[8.0].define(version: 2023_01_09_013025) do
     t.boolean "prompt_for_records", default: true
     t.string "color"
     t.hstore "preferences"
+    t.datetime "prompt_snoozed_until"
     t.index ["preferences"], name: "index_vehicles_on_preferences", using: :gin
     t.index ["user_id"], name: "index_vehicles_on_user_id"
   end

--- a/api/test/controllers/prompt_controls_controller_test.rb
+++ b/api/test/controllers/prompt_controls_controller_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class V2::PromptControlsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @vehicle = vehicles(:one)
+  end
+
+  test 'remind me later snoozes prompts for one month' do
+    token = NotificationToken.generate(vehicle_id: @vehicle.id, action: 'remind_me_later')
+
+    post remind_me_later_url(token: token)
+
+    assert_response :success
+    assert_match 'snoozed for one month', response.body
+    assert @vehicle.reload.prompt_snoozed_until
+    assert @vehicle.prompt_snoozed_until > 3.weeks.from_now
+  end
+
+  test 'mute disables prompt emails' do
+    assert @vehicle.preferences.send_prompt_for_records
+
+    token = NotificationToken.generate(vehicle_id: @vehicle.id, action: 'mute')
+    post mute_prompt_url(token: token)
+
+    assert_response :success
+    assert_match 'muted', response.body
+    assert_not @vehicle.reload.preferences.send_prompt_for_records
+  end
+
+  test 'invalid token' do
+    post remind_me_later_url(token: 'invalid')
+
+    assert_response :not_found
+    assert_match 'invalid or has expired', response.body
+  end
+end

--- a/api/test/controllers/unsubscribes_controller_test.rb
+++ b/api/test/controllers/unsubscribes_controller_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class V2::UnsubscribesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @vehicle = vehicles(:one)
+  end
+
+  test 'unsubscribe from prompt emails' do
+    assert @vehicle.preferences.send_prompt_for_records
+
+    token = NotificationToken.generate(vehicle_id: @vehicle.id, action: 'prompt')
+    get unsubscribe_url(token: token)
+
+    assert_response :success
+    assert_match 'unsubscribed', response.body
+    assert_not @vehicle.reload.preferences.send_prompt_for_records
+  end
+
+  test 'unsubscribe from reminder emails' do
+    assert @vehicle.preferences.send_reminder_emails
+
+    token = NotificationToken.generate(vehicle_id: @vehicle.id, action: 'reminders')
+    get unsubscribe_url(token: token)
+
+    assert_response :success
+    assert_match 'unsubscribed', response.body
+    assert_not @vehicle.reload.preferences.send_reminder_emails
+  end
+
+  test 'invalid token' do
+    get unsubscribe_url(token: 'invalid')
+
+    assert_response :not_found
+    assert_match 'invalid or has expired', response.body
+  end
+end

--- a/api/test/mailers/prompt_user_mailer_test.rb
+++ b/api/test/mailers/prompt_user_mailer_test.rb
@@ -1,7 +1,22 @@
 require 'test_helper'
 
 class PromptUserMailerTest < ActionMailer::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    new_session
+    @vehicle = @user.vehicles.first
+  end
+
+  test "add_record includes prompt control links" do
+    mail = PromptUserMailer.add_record(@user, @vehicle)
+
+    assert_equal "Have you done anything to your #{@vehicle.name} lately?", mail.subject
+    assert_equal [@user.email], mail.to
+    assert_equal ['spanner@nicinabox.com'], mail.from
+
+    body = mail.body.encoded
+    assert_match 'Remind Me Later', body
+    assert_match 'Mute', body
+    assert_match '/prompt_controls/', body
+    assert_match '/unsubscribe/', body
+  end
 end

--- a/api/test/mailers/reminders_mailer_test.rb
+++ b/api/test/mailers/reminders_mailer_test.rb
@@ -14,6 +14,8 @@ class RemindersMailerTest < ActionMailer::TestCase
     assert_equal ["user1@test"], mail.to
     assert_equal ["spanner@nicinabox.com"], mail.from
     assert_match "Hello", mail.body.encoded
+    assert_match "data:image/png;base64,", mail.body.encoded
+    assert_match '/unsubscribe/', mail.body.encoded
   end
 
   test "reminder_upcoming" do
@@ -26,6 +28,7 @@ class RemindersMailerTest < ActionMailer::TestCase
     assert_equal ["user2@test"], mail.to
     assert_equal ["spanner@nicinabox.com"], mail.from
     assert_match "14 days", mail.body.encoded
+    assert_match '/unsubscribe/', mail.body.encoded
   end
 
 end

--- a/web/src/__fixtures__/vehicle.ts
+++ b/web/src/__fixtures__/vehicle.ts
@@ -20,6 +20,7 @@ const vehicleFixture: API.Vehicle = {
         sendPromptForRecords: true,
         showMileageAdjustmentRecords: true,
     },
+    promptSnoozedUntil: null,
 };
 
 export default vehicleFixture;

--- a/web/src/components/forms/VehicleForm/VehicleForm.tsx
+++ b/web/src/components/forms/VehicleForm/VehicleForm.tsx
@@ -1,5 +1,6 @@
 import {
     Box,
+    Button,
     FormControl,
     FormHelperText,
     FormLabel,
@@ -58,6 +59,8 @@ export const VehicleForm: React.FC<VehicleFormProps> = ({ vehicle }) => {
         },
     });
 
+    const { mutate: updateVehicle } = useMutation(vehicles.createOrUpdateVehicle);
+
     const { mutate: destroyVehicle } = useMutation(vehicles.destroyVehicle, {
         onSuccess() {
             router.replace(vehiclesPath());
@@ -73,6 +76,25 @@ export const VehicleForm: React.FC<VehicleFormProps> = ({ vehicle }) => {
     const handleSubmit = (e) => {
         e.preventDefault();
         createOrUpdateVehicle(formData);
+    };
+
+    const handleSnooze = () => {
+        if (!vehicle) return;
+        updateVehicle({
+            id: vehicle.id,
+            promptSnoozedUntil: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        });
+    };
+
+    const handleMute = () => {
+        if (!vehicle) return;
+        updateVehicle({
+            id: vehicle.id,
+            preferences: {
+                ...formData.preferences,
+                sendPromptForRecords: false,
+            },
+        });
     };
 
     return (
@@ -218,11 +240,44 @@ export const VehicleForm: React.FC<VehicleFormProps> = ({ vehicle }) => {
             </form>
 
             {Boolean(vehicle) && (
-                <DangerZone>
-                    <DestroyButton onConfirm={handleDeleteVehicle}>
-                        Delete vehicle
-                    </DestroyButton>
-                </DangerZone>
+                <>
+                    <FormSection heading="Prompt Notifications">
+                        <Stack
+                            spacing={4}
+                            direction="row"
+                            align="center"
+                        >
+                            <Button
+                                colorScheme="blue"
+                                size="sm"
+                                onClick={handleSnooze}
+                            >
+                                Remind Me Later
+                            </Button>
+                            <Button
+                                colorScheme="red"
+                                size="sm"
+                                onClick={handleMute}
+                            >
+                                Mute
+                            </Button>
+                        </Stack>
+                        {vehicle!.promptSnoozedUntil && (
+                            <FormHelperText mt={2}>
+                                Prompts snoozed until{' '}
+                                {new Date(
+                                    vehicle!.promptSnoozedUntil,
+                                ).toLocaleDateString()}
+                            </FormHelperText>
+                        )}
+                    </FormSection>
+
+                    <DangerZone>
+                        <DestroyButton onConfirm={handleDeleteVehicle}>
+                            Delete vehicle
+                        </DestroyButton>
+                    </DangerZone>
+                </>
             )}
         </>
     );

--- a/web/src/tsd/api.d.ts
+++ b/web/src/tsd/api.d.ts
@@ -80,5 +80,6 @@ declare namespace API {
         reminders: API.Reminder[];
         color: string | null;
         preferences: VehiclePreferences;
+        promptSnoozedUntil: string | null;
     }
 }


### PR DESCRIPTION
## Summary

Adds notification controls to mailers and the prompt-for-new-records flow:

- **Unsubscribe links** in all mailer footers (reminder and prompt emails)
- **Remind Me Later** (1-month snooze) and **Mute** (unsubscribe) actions in prompt emails
- Signed token-based URLs for secure one-click actions without login
- Per-vehicle preference controls (send_prompt_for_records, send_reminder_emails)
- Frontend UI in vehicle settings for snooze/mute

## Changes

### Backend
- NotificationToken service for signed, expiring tokens
- UnsubscribesController - GET /unsubscribe/:token
- PromptControlsController - POST /prompt_controls/:token/remind_me_later and /mute
- Mailer helpers for generating tokenized URLs
- prompt_snoozed_until column on vehicles
- Vehicle#prompt_for_new_record! respects snooze

### Frontend
- Vehicle form now has Remind Me Later and Mute buttons
- Shows active snooze date

### Tests
- Full test coverage for controllers and mailers (35 tests, 0 failures)