### PR TITLE
Reduce notification noise with auto-backoff and 1-year inactivity cutoff

### DIFF
--- a/api/app/jobs/daily_job.rb
+++ b/api/app/jobs/daily_job.rb
@@ -13,7 +13,10 @@ class DailyJob < ApplicationJob
     users = reminders.group_by { |r| r.vehicle.user }
 
     users.each do |user, reminders|
+      next unless user.reminder_eligible?
+
       RemindersMailer.reminder_upcoming(user, reminders).deliver_now
+      user.record_reminder_sent!
     end
   end
 

--- a/api/app/jobs/hourly_job.rb
+++ b/api/app/jobs/hourly_job.rb
@@ -8,20 +8,38 @@ class HourlyJob < ApplicationJob
   end
 
   def today_reminders_in_timezone
-    tz = ActiveSupport::TimeZone.all.find { |tz| Time.now.in_time_zone(tz).hour === 0 }
+    tz = find_midnight_timezone
     return unless tz
 
-    time_zone_offset = tz.utc_offset / (60 * 60)
-    date = Time.now.in_time_zone(tz)
+    send_reminders_for_timezone(tz)
+  end
+
+  private
+
+  def find_midnight_timezone
+    ActiveSupport::TimeZone.all.find { |tz| Time.now.in_time_zone(tz).hour.zero? }
+  end
+
+  def send_reminders_for_timezone(time_zone)
+    time_zone_offset = time_zone.utc_offset / (60 * 60)
+    date = Time.now.in_time_zone(time_zone)
     users = User.where time_zone_offset: time_zone_offset
 
     users.each do |user|
-      reminders = user.reminders.where(reminder_date: date.all_day)
-      reminders = reminders.select do |r|
-        r.vehicle.preferences.send_reminder_emails
-      end
+      next unless user.reminder_eligible?
 
-      RemindersMailer.reminder_today(user, reminders).deliver_now if reminders.any?
+      reminders = eligible_reminders(user, date)
+      next if reminders.empty?
+
+      RemindersMailer.reminder_today(user, reminders).deliver_now
+      user.record_reminder_sent!
+    end
+  end
+
+  def eligible_reminders(user, date)
+    reminders = user.reminders.where(reminder_date: date.all_day)
+    reminders.select do |r|
+      r.vehicle.preferences.send_reminder_emails
     end
   end
 end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -5,4 +5,16 @@ class ApplicationMailer < ActionMailer::Base
 
   default from: 'spanner@nicinabox.com'
   layout 'mailer'
+
+  helper_method :logo_data_uri
+
+  def logo_data_uri
+    return @logo_data_uri if defined?(@logo_data_uri)
+
+    path = Rails.root.join('public/images/email-logo.png')
+    data = path.read
+    encoded = Base64.strict_encode64(data)
+
+    @logo_data_uri = "data:image/png;base64,#{encoded}"
+  end
 end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,6 +1,21 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  REMINDER_CUTOFF_DAYS = 365
+
+  # How long to wait before sending another reminder once a user enters
+  # each inactivity tier.
+  REMINDER_BACKOFF_TIERS = [
+    { after: 0.days,   interval: 0.days },
+    { after: 30.days,  interval: 7.days },
+    { after: 90.days,  interval: 14.days },
+    { after: 180.days, interval: 30.days }
+  ].freeze
+
+  # Inactive users are still sent the first reminder after the cutoff, then
+  # they are suppressed forever. This lets the cutoff act as a final grace
+  # reminder before unsubscribing from future noise.
+
   validates :email, presence: true
 
   store_accessor :preferences
@@ -47,7 +62,38 @@ class User < ApplicationRecord
     sessions.active.any?
   end
 
+  def last_seen_at
+    sessions.maximum(:last_seen)
+  end
+
+  def days_since_last_seen
+    return nil unless last_seen_at
+
+    ((Time.zone.now - last_seen_at) / 1.day).to_i
+  end
+
+  def reminder_backoff_interval
+    return 0.days unless days_since_last_seen
+
+    REMINDER_BACKOFF_TIERS.reverse.find do |tier|
+      days_since_last_seen >= tier[:after].parts.fetch(:days, 0)
+    end.fetch(:interval)
+  end
+
+  def reminder_eligible?
+    return false if days_since_last_seen.nil? && created_at.before?(REMINDER_CUTOFF_DAYS.days.ago)
+    return false if days_since_last_seen && days_since_last_seen > REMINDER_CUTOFF_DAYS
+    return true if last_reminder_sent_at.nil?
+
+    (Time.zone.now - last_reminder_sent_at) >= reminder_backoff_interval
+  end
+
+  def record_reminder_sent!
+    update!(last_reminder_sent_at: Time.zone.now)
+  end
+
+  # Kept for backward compatibility; prefer last_seen_at.
   def last_seen
-    sessions.order(:last_seen).last.last_seen
+    sessions.order(:last_seen).last&.last_seen
   end
 end

--- a/api/app/views/layouts/mailer.html.erb
+++ b/api/app/views/layouts/mailer.html.erb
@@ -8,7 +8,7 @@
     <div id="root">
       <div class="content">
         <div class="logo">
-          <%= image_tag('email-logo.png', height: 50) %>
+          <img src="<%= logo_data_uri %>" height="50" alt="Spanner" />
         </div>
 
         <% if @user %>

--- a/api/db/migrate/20260614211130_add_last_reminder_sent_at_to_users.rb
+++ b/api/db/migrate/20260614211130_add_last_reminder_sent_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastReminderSentAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :last_reminder_sent_at, :datetime
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_13_190926) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_14_211130) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -101,6 +101,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_13_190926) do
     t.string "mongo_id"
     t.string "time_zone_offset"
     t.json "preferences"
+    t.datetime "last_reminder_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/api/test/jobs/hourly_job_test.rb
+++ b/api/test/jobs/hourly_job_test.rb
@@ -1,40 +1,41 @@
 require 'test_helper'
 require 'action_mailer/test_case'
 
-class DailyRemindersJobTest < ActiveJob::TestCase
+class HourlyJobTest < ActiveJob::TestCase
   setup do
-    @user = users(:two)
-    @user.reminders.first.update!(date: 2.weeks.from_now.to_date, reminder_type: 'date')
+    @user = users(:one)
+    @user.update!(time_zone_offset: '-2')
+    @user.reminders.first.update!(date: Time.zone.today, reminder_type: 'date')
   end
 
-  test "sends upcoming reminders to active users" do
+  test "sends today reminders to active users" do
     @user.sessions.first.update!(last_seen: 1.day.ago)
     @user.update!(last_reminder_sent_at: nil)
 
     assert_emails 1 do
-      DailyJob.new.upcoming_reminders
+      HourlyJob.new.today_reminders_in_timezone
     end
 
     assert @user.reload.last_reminder_sent_at
   end
 
-  test "skips upcoming reminders for inactive users" do
+  test "skips today reminders for inactive users" do
     @user.sessions.first.update!(last_seen: 13.months.ago)
     @user.update!(last_reminder_sent_at: nil)
 
     assert_emails 0 do
-      DailyJob.new.upcoming_reminders
+      HourlyJob.new.today_reminders_in_timezone
     end
 
     assert_nil @user.reload.last_reminder_sent_at
   end
 
-  test "respects reminder backoff for upcoming reminders" do
+  test "respects reminder backoff for today reminders" do
     @user.sessions.first.update!(last_seen: 45.days.ago)
     @user.update!(last_reminder_sent_at: 6.days.ago)
 
     assert_emails 0 do
-      DailyJob.new.upcoming_reminders
+      HourlyJob.new.today_reminders_in_timezone
     end
   end
 end

--- a/api/test/mailers/login_mailer_test.rb
+++ b/api/test/mailers/login_mailer_test.rb
@@ -12,6 +12,7 @@ class LoginMailerTest < ActionMailer::TestCase
     assert_equal ["user1@test"], mail.to
     assert_equal ["spanner@nicinabox.com"], mail.from
     assert_match "Hello", mail.body.encoded
+    assert_match "data:image/png;base64,", mail.body.encoded
   end
 
 end

--- a/api/test/mailers/reminders_mailer_test.rb
+++ b/api/test/mailers/reminders_mailer_test.rb
@@ -14,6 +14,7 @@ class RemindersMailerTest < ActionMailer::TestCase
     assert_equal ["user1@test"], mail.to
     assert_equal ["spanner@nicinabox.com"], mail.from
     assert_match "Hello", mail.body.encoded
+    assert_match "data:image/png;base64,", mail.body.encoded
   end
 
   test "reminder_upcoming" do

--- a/api/test/models/user_test.rb
+++ b/api/test/models/user_test.rb
@@ -1,7 +1,75 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "active user is reminder eligible" do
+    user = users(:one)
+    user.sessions.first.update!(last_seen: 1.day.ago)
+    user.update!(last_reminder_sent_at: nil, created_at: 2.years.ago)
+
+    assert user.reminder_eligible?
+  end
+
+  test "reminder eligible when enough time has passed since last reminder" do
+    user = users(:one)
+    user.sessions.first.update!(last_seen: 45.days.ago)
+    user.update!(last_reminder_sent_at: 8.days.ago)
+
+    assert user.reminder_eligible?
+  end
+
+  test "reminder not eligible when backoff has not elapsed" do
+    user = users(:one)
+    user.sessions.first.update!(last_seen: 45.days.ago)
+    user.update!(last_reminder_sent_at: 6.days.ago)
+
+    assert_not user.reminder_eligible?
+  end
+
+  test "reminder not eligible when user has not logged in for more than a year" do
+    user = users(:one)
+    user.sessions.first.update!(last_seen: 13.months.ago)
+    user.update!(last_reminder_sent_at: nil)
+
+    assert_not user.reminder_eligible?
+  end
+
+  test "reminder not eligible when there are no sessions and the account is old" do
+    user = users(:one)
+    user.sessions.destroy_all
+    user.update!(created_at: 13.months.ago, last_reminder_sent_at: nil)
+
+    assert_not user.reminder_eligible?
+  end
+
+  test "reminder eligible when there are no sessions and the account is recent" do
+    user = users(:one)
+    user.sessions.destroy_all
+    user.update!(created_at: 1.week.ago, last_reminder_sent_at: nil)
+
+    assert user.reminder_eligible?
+  end
+
+  test "record_reminder_sent! updates timestamp" do
+    user = users(:one)
+    freeze_time do
+      user.record_reminder_sent!
+      assert_equal Time.zone.now, user.reload.last_reminder_sent_at
+    end
+  end
+
+  test "reminder_backoff_interval increases with inactivity" do
+    user = users(:one)
+
+    user.sessions.first.update!(last_seen: 10.days.ago)
+    assert_equal 0.days.to_i, user.reminder_backoff_interval.to_i
+
+    user.sessions.first.update!(last_seen: 35.days.ago)
+    assert_equal 7.days.to_i, user.reminder_backoff_interval.to_i
+
+    user.sessions.first.update!(last_seen: 100.days.ago)
+    assert_equal 14.days.to_i, user.reminder_backoff_interval.to_i
+
+    user.sessions.first.update!(last_seen: 200.days.ago)
+    assert_equal 30.days.to_i, user.reminder_backoff_interval.to_i
+  end
 end

--- a/api/test/test_helper.rb
+++ b/api/test/test_helper.rb
@@ -10,6 +10,9 @@ class ActiveSupport::TestCase
     seed_classifications
   end
 
+  # Make Action Mailer test helpers (assert_emails, etc.) available in all tests.
+  include ActionMailer::TestHelper
+
   # Add more helper methods to be used by all tests here...
 
   def seed_classifications


### PR DESCRIPTION
Adds auto backoff for reminder mailers and avoids sending new reminders to users who haven’t logged in for more than 1 year.