### PR TITLE
Add verified user email change flow

### DIFF
--- a/api/app/controllers/v2/users_controller.rb
+++ b/api/app/controllers/v2/users_controller.rb
@@ -2,6 +2,8 @@
 
 module V2
   class UsersController < ApplicationController
+    skip_before_action :authenticate, only: %i[confirm_email]
+
     def index
       render json: current_user
     end
@@ -11,12 +13,41 @@ module V2
       render json: current_user
     end
 
+    # Authenticated. Begins an email change request for the current user.
+    # Stores the requested (new) email and enqueues confirmation emails to
+    # both the new and old addresses. The current `email` is unchanged until
+    # the new address is confirmed via #confirm_email.
+    def request_email_change
+      new_email = params.dig(:user, :email).to_s.strip
+      return respond_with_error('Email is required', status: :unprocessable_entity) if new_email.blank?
+
+      current_user.request_email_change!(new_email)
+
+      mailer_host = params[:host].presence || request.base_url
+      EmailChangeMailer.confirm_email(current_user, host: mailer_host).deliver_later
+      EmailChangeMailer.notify_old_email(current_user).deliver_later
+
+      head :no_content
+    rescue ActiveRecord::RecordInvalid
+      respond_with_errors(current_user)
+    end
+
+    # Public (no auth). Redeems an email change confirmation token and
+    # commits the new email.
+    def confirm_email
+      if User.confirm_email_change!(params[:token])
+        render json: { message: 'Your email has been updated.' }, status: :ok
+      else
+        respond_with_error 'Invalid or expired email confirmation link', status: 401
+      end
+    end
+
     private
 
     def user_params
       params
         .require(:user)
-        .permit(:email, :time_zone_offset,
+        .permit(:time_zone_offset,
                 preferences: [
                   vehicles_sort_order: []
                 ])

--- a/api/app/mailers/email_change_mailer.rb
+++ b/api/app/mailers/email_change_mailer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class EmailChangeMailer < ApplicationMailer
+  # Sent to the NEW (unconfirmed) email address with a confirmation link.
+  def confirm_email(user, url_options)
+    @user = user
+    @url_options = url_options
+    @expires_at = expires_time
+    mail to: @user.unconfirmed_email,
+         subject: "Confirm your new email for Spanner (expires #{@expires_at})"
+  end
+
+  # Sent to the OLD (current) email address to notify the user that an
+  # email change was requested. This protects against silent account
+  # takeover.
+  def notify_old_email(user)
+    @user = user
+    mail to: @user.email,
+         subject: 'An email change was requested for your Spanner account'
+  end
+
+  private
+
+  def expires_time
+    now = Time.now.in_time_zone @user.time_zone
+    time = now + User::EMAIL_CONFIRMATION_TOKEN_TTL
+    time.to_fs :short
+  end
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -16,7 +16,12 @@ class User < ApplicationRecord
   # they are suppressed forever. This lets the cutoff act as a final grace
   # reminder before unsubscribing from future noise.
 
+  EMAIL_CONFIRMATION_TOKEN_TTL = 15.minutes
+
   validates :email, presence: true
+  validates :unconfirmed_email,
+            allow_nil: true,
+            format: { with: URI::MailTo::EMAIL_REGEXP, message: 'is invalid' }
 
   store_accessor :preferences
 
@@ -25,7 +30,54 @@ class User < ApplicationRecord
   has_many :reminders, through: :vehicles
   has_many :records, through: :vehicles
 
-  before_save { |user| user.email = user.email.strip.downcase }
+  before_save { |user| user.email = user.email.strip.downcase if user.email }
+  before_save { |user| user.unconfirmed_email = user.unconfirmed_email.strip.downcase if user.unconfirmed_email }
+
+  # Begins an email change request. Stores the requested (new) email and a
+  # single-use confirmation token, but does NOT modify the current `email`.
+  # Raises ActiveRecord::RecordInvalid if the new email is already taken or
+  # otherwise invalid.
+  def request_email_change!(new_email)
+    new_email = new_email.to_s.strip.downcase
+    raise ActiveRecord::RecordInvalid, self if new_email.blank?
+    raise ActiveRecord::RecordInvalid, self if new_email == email
+
+    if self.class.exists?(email: new_email)
+      errors.add(:email, 'has already been taken')
+      raise ActiveRecord::RecordInvalid, self
+    end
+
+    update!(
+      unconfirmed_email: new_email,
+      email_confirmation_token: SecureRandom.urlsafe_base64,
+      email_confirmation_token_valid_until: EMAIL_CONFIRMATION_TOKEN_TTL.from_now
+    )
+  end
+
+  # Redeems a pending email change for the given token, committing the new
+  # email. Returns the user on success, nil if the token is invalid/expired.
+  # Re-validates uniqueness at commit time to guard against races.
+  def self.confirm_email_change!(token)
+    return nil if token.blank?
+
+    user = where(email_confirmation_token: token)
+           .where('email_confirmation_token_valid_until > ?', Time.zone.now)
+           .first
+    return nil unless user&.unconfirmed_email
+
+    if exists?(email: user.unconfirmed_email)
+      user.errors.add(:email, 'has already been taken')
+      return nil
+    end
+
+    user.update!(
+      email: user.unconfirmed_email,
+      unconfirmed_email: nil,
+      email_confirmation_token: nil,
+      email_confirmation_token_valid_until: nil
+    )
+    user
+  end
 
   def preferences
     @preferences ||= UserPreferences.new(self[:preferences] || {})

--- a/api/app/serializers/user_serializer.rb
+++ b/api/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :email, :time_zone_offset, :created_at, :updated_at, :admin?, :preferences
+  attributes :id, :email, :unconfirmed_email, :time_zone_offset, :created_at, :updated_at, :admin?, :preferences
 end

--- a/api/app/views/email_change_mailer/confirm_email.html.erb
+++ b/api/app/views/email_change_mailer/confirm_email.html.erb
@@ -1,0 +1,17 @@
+<p>
+  You requested to change the email on your Spanner account from
+  <strong><%= @user.email %></strong> to <strong><%= @user.unconfirmed_email %></strong>.
+</p>
+<p>
+  Click the button below to confirm the new email address.
+</p>
+<p>
+  <%= link_to 'Confirm new email', confirm_email_url(@user.email_confirmation_token, @url_options), class: 'button' %>
+</p>
+
+<p>
+  This link expires <%= @expires_at %> and can only be used once.
+</p>
+<p>
+  If you did not request this change, you can safely ignore this email.
+</p>

--- a/api/app/views/email_change_mailer/confirm_email.text.erb
+++ b/api/app/views/email_change_mailer/confirm_email.text.erb
@@ -1,0 +1,10 @@
+You requested to change the email on your Spanner account from
+<%= @user.email %> to <%= @user.unconfirmed_email %>.
+
+Confirm the new email address by visiting the link below:
+
+<%= confirm_email_url(@user.email_confirmation_token, @url_options) %>
+
+This link expires <%= @expires_at %> and can only be used once.
+
+If you did not request this change, you can safely ignore this email.

--- a/api/app/views/email_change_mailer/notify_old_email.html.erb
+++ b/api/app/views/email_change_mailer/notify_old_email.html.erb
@@ -1,0 +1,12 @@
+<p>
+  Someone requested to change the email on your Spanner account from
+  <strong><%= @user.email %></strong> to <strong><%= @user.unconfirmed_email %></strong>.
+</p>
+<p>
+  We sent a confirmation link to the new address. The change will not take
+  effect until that link is used.
+</p>
+<p>
+  If you did not request this change, please secure your account and ignore
+  this email.
+</p>

--- a/api/app/views/email_change_mailer/notify_old_email.text.erb
+++ b/api/app/views/email_change_mailer/notify_old_email.text.erb
@@ -1,0 +1,8 @@
+Someone requested to change the email on your Spanner account from
+<%= @user.email %> to <%= @user.unconfirmed_email %>.
+
+We sent a confirmation link to the new address. The change will not take
+effect until that link is used.
+
+If you did not request this change, please secure your account and ignore
+this email.

--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -36,6 +36,10 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Use the test queue adapter so Active Job jobs can be performed inline
+  # during tests (e.g. perform_enqueued_jobs).
+  config.active_job.queue_adapter = :test
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     post 'sessions', to: 'sessions#create'
 
     get 'login(/:login_token)', to: 'sessions#login', as: 'login'
+    get 'confirm_email(/:token)', to: 'users#confirm_email', as: 'confirm_email'
   end
 
   scope module: :v2, constraints: ApiConstraint.new(version: 2) do
@@ -31,6 +32,7 @@ Rails.application.routes.draw do
 
     get 'user', to: 'users#index'
     put 'user', to: 'users#update'
+    post 'user/email_change', to: 'users#request_email_change', as: 'email_change_user'
 
     delete 'sessions/:id', to: 'sessions#destroy'
     get 'sessions', to: 'sessions#index'

--- a/api/db/migrate/20260619175800_add_email_change_to_users.rb
+++ b/api/db/migrate/20260619175800_add_email_change_to_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddEmailChangeToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :unconfirmed_email, :string
+    add_column :users, :email_confirmation_token, :string
+    add_column :users, :email_confirmation_token_valid_until, :datetime
+    add_index :users, :email_confirmation_token
+  end
+end

--- a/api/test/controllers/users_controller_test.rb
+++ b/api/test/controllers/users_controller_test.rb
@@ -26,19 +26,110 @@ module V2
     end
 
     test 'should update current user' do
+      put user_url, params: { user: { time_zone_offset: '-5' } }, headers: @headers
+      assert_response :success
+      @user.reload
+      assert_equal '-5', @user.time_zone_offset
+    end
+
+    test 'should not change email via update' do
       put user_url, params: { user: { email: 'updated@example.com' } }, headers: @headers
       assert_response :success
-      body = JSON.parse(@response.body)
-      assert_equal 'updated@example.com', body['email']
       @user.reload
-      assert_equal 'updated@example.com', @user.email
+      assert_equal 'testuser@example.com', @user.email
     end
 
     test 'should not update user with invalid params' do
       put user_url, params: { user: { email: '' } }, headers: @headers
+      # `email` is now ignored by user_params, so the update succeeds and
+      # email is unchanged.
+      assert_response :success
+      @user.reload
+      assert_equal 'testuser@example.com', @user.email
+    end
+
+    test 'should request email change' do
+      perform_enqueued_jobs do
+        assert_emails 2 do
+          post email_change_user_url,
+               params: { user: { email: 'new@example.com' }, host: 'http://localhost:8080' },
+               headers: @headers
+        end
+      end
+      assert_response :no_content
+
+      @user.reload
+      assert_equal 'testuser@example.com', @user.email
+      assert_equal 'new@example.com', @user.unconfirmed_email
+      assert_not_nil @user.email_confirmation_token
+      assert @user.email_confirmation_token_valid_until > Time.zone.now
+    end
+
+    test 'should not request email change to a duplicate email' do
+      User.create!(email: 'taken@example.com')
+
+      post email_change_user_url,
+           params: { user: { email: 'taken@example.com' }, host: 'http://localhost:8080' },
+           headers: @headers
       assert_response :unprocessable_entity
-      body = JSON.parse(@response.body)
-      assert body['errors'].present?
+
+      @user.reload
+      assert_nil @user.unconfirmed_email
+    end
+
+    test 'should not request email change without email' do
+      post email_change_user_url,
+           params: { user: { email: '' }, host: 'http://localhost:8080' },
+           headers: @headers
+      assert_response :unprocessable_entity
+    end
+
+    test 'should not request email change to the same email' do
+      post email_change_user_url,
+           params: { user: { email: 'testuser@example.com' }, host: 'http://localhost:8080' },
+           headers: @headers
+      assert_response :unprocessable_entity
+    end
+
+    test 'should confirm email change with a valid token' do
+      @user.request_email_change!('new@example.com')
+      token = @user.reload.email_confirmation_token
+
+      get confirm_email_url(token)
+      assert_response :success
+
+      @user.reload
+      assert_equal 'new@example.com', @user.email
+      assert_nil @user.unconfirmed_email
+      assert_nil @user.email_confirmation_token
+    end
+
+    test 'should not confirm email change with an invalid token' do
+      get confirm_email_url('invalid-token')
+      assert_response :unauthorized
+
+      @user.reload
+      assert_equal 'testuser@example.com', @user.email
+    end
+
+    test 'should not confirm email change with an expired token' do
+      @user.request_email_change!('new@example.com')
+      @user.update!(email_confirmation_token_valid_until: 1.minute.ago)
+
+      get confirm_email_url(@user.reload.email_confirmation_token)
+      assert_response :unauthorized
+
+      @user.reload
+      assert_equal 'testuser@example.com', @user.email
+      assert_equal 'new@example.com', @user.unconfirmed_email
+    end
+
+    test 'confirm_email does not require authentication' do
+      @user.request_email_change!('new@example.com')
+      token = @user.reload.email_confirmation_token
+
+      get confirm_email_url(token)
+      assert_response :success
     end
   end
 end

--- a/api/test/mailers/previews/email_change_mailer_preview.rb
+++ b/api/test/mailers/previews/email_change_mailer_preview.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/email_change_mailer
+class EmailChangeMailerPreview < ActionMailer::Preview
+  def confirm_email
+    user = User.first
+    user.assign_attributes(
+      unconfirmed_email: 'new-email@example.com',
+      email_confirmation_token: SecureRandom.urlsafe_base64,
+      email_confirmation_token_valid_until: 15.minutes.from_now
+    )
+    EmailChangeMailer.confirm_email(user, host: 'localhost:3000', protocol: 'http')
+  end
+
+  def notify_old_email
+    user = User.first
+    user.assign_attributes(
+      unconfirmed_email: 'new-email@example.com',
+      email_confirmation_token: SecureRandom.urlsafe_base64,
+      email_confirmation_token_valid_until: 15.minutes.from_now
+    )
+    EmailChangeMailer.notify_old_email(user)
+  end
+end

--- a/api/test/models/user_test.rb
+++ b/api/test/models/user_test.rb
@@ -85,4 +85,82 @@ class UserTest < ActiveSupport::TestCase
     user.sessions.first.update!(last_seen: 200.days.ago)
     assert_equal 30.days.to_i, user.reminder_backoff_interval.to_i
   end
+
+  test 'request_email_change! stores unconfirmed email without changing email' do
+    user = users(:one)
+
+    user.request_email_change!('new@example.com')
+
+    assert_equal 'user1@test', user.reload.email
+    assert_equal 'new@example.com', user.unconfirmed_email
+    assert_not_nil user.email_confirmation_token
+    assert user.email_confirmation_token_valid_until > Time.zone.now
+  end
+
+  test 'request_email_change! normalizes the new email' do
+    user = users(:one)
+
+    user.request_email_change!('  NEW@Example.com  ')
+
+    assert_equal 'new@example.com', user.reload.unconfirmed_email
+  end
+
+  test 'request_email_change! rejects a blank email' do
+    user = users(:one)
+
+    assert_raises(ActiveRecord::RecordInvalid) { user.request_email_change!('') }
+    assert_raises(ActiveRecord::RecordInvalid) { user.request_email_change!('   ') }
+  end
+
+  test 'request_email_change! rejects the current email' do
+    user = users(:one)
+
+    assert_raises(ActiveRecord::RecordInvalid) { user.request_email_change!(user.email) }
+  end
+
+  test 'request_email_change! rejects a duplicate email' do
+    user = users(:one)
+    other = users(:two)
+
+    assert_raises(ActiveRecord::RecordInvalid) { user.request_email_change!(other.email) }
+  end
+
+  test 'confirm_email_change! commits the new email and clears the token' do
+    user = users(:one)
+    user.request_email_change!('new@example.com')
+    token = user.reload.email_confirmation_token
+
+    confirmed = User.confirm_email_change!(token)
+
+    assert_equal user, confirmed
+    assert_equal 'new@example.com', user.reload.email
+    assert_nil user.unconfirmed_email
+    assert_nil user.email_confirmation_token
+    assert_nil user.email_confirmation_token_valid_until
+  end
+
+  test 'confirm_email_change! returns nil for an invalid token' do
+    assert_nil User.confirm_email_change!('does-not-exist')
+  end
+
+  test 'confirm_email_change! returns nil for an expired token' do
+    user = users(:one)
+    user.request_email_change!('new@example.com')
+    user.update!(email_confirmation_token_valid_until: 1.minute.ago)
+
+    assert_nil User.confirm_email_change!(user.reload.email_confirmation_token)
+    assert_equal 'user1@test', user.reload.email
+    assert_equal 'new@example.com', user.unconfirmed_email
+  end
+
+  test 'confirm_email_change! rejects a token whose new email is already taken' do
+    user = users(:one)
+    user.request_email_change!('new@example.com')
+    token = user.reload.email_confirmation_token
+
+    User.create!(email: 'new@example.com')
+
+    assert_nil User.confirm_email_change!(token)
+    assert_equal 'user1@test', user.reload.email
+  end
 end


### PR DESCRIPTION
Add verified user email change flow

Add support for users to change their account email with verification,
consistent with the existing magic-link auth philosophy.

- Migration adds unconfirmed_email, email_confirmation_token, and
  email_confirmation_token_valid_until columns to users.
- User#request_email_change! stores the pending (new) email and a
  single-use confirmation token without modifying the current email;
  rejects blank, duplicate, and same-as-current emails.
- User.confirm_email_change! redeems a token within its 15-minute
  validity and commits the new email, re-checking uniqueness at commit
  time to guard against races.
- New authenticated route POST /user/email_change enqueues confirmation
  and notification emails (EmailChangeMailer) to both the new and old
  addresses.
- New public route GET /confirm_email/:token redeems the token.
- Remove :email from user_params so PUT /user can no longer change
  email directly (security: prevents unverified email changes).
- Expose unconfirmed_email in the serializer so clients can show
  pending-change state.
- Set active_job queue_adapter to :test in the test environment so
  deliver_later jobs run inline for assert_emails.
- Add model and controller tests covering request, confirm, duplicate/
  blank/same-email rejection, invalid/expired tokens, and no-auth
  confirmation.