### PR TITLE
Replace hardcoded nicinabox references with env vars

### DIFF
--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -3,7 +3,7 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::DateHelper
 
-  default from: 'spanner@nicinabox.com'
+  default from: ENV.fetch('FROM_EMAIL', 'noreply@localhost')
   layout 'mailer'
 
   helper_method :logo_data_uri

--- a/api/app/views/layouts/mailer.html.erb
+++ b/api/app/views/layouts/mailer.html.erb
@@ -19,10 +19,11 @@
 
         <%= yield %>
 
+        <% app_url = ENV.fetch('APP_URL', 'http://localhost:3000') %>
         <div class="footer">
           <small class="text-muted">
             View all your vehicles at
-            <a class="text-muted" href="https://spanner.nicinabox.com">https://spanner.nicinabox.com</a>
+            <a class="text-muted" href="<%= app_url %>"><%= app_url %></a>
           </small>
           <div>
             <small class="text-muted">

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.configure do
-  host = 'https://spanner.nicinabox.com'
+  host = ENV.fetch('APP_URL', 'http://localhost:3000')
   api_host = ENV.fetch('API_HOST', nil)
 
   # Settings specified here will take precedence over those in config/application.rb.

--- a/api/test/mailers/login_mailer_test.rb
+++ b/api/test/mailers/login_mailer_test.rb
@@ -12,7 +12,7 @@ class LoginMailerTest < ActionMailer::TestCase
 
     assert_match 'Sign in to Spanner', mail.subject
     assert_equal ['user1@test'], mail.to
-    assert_equal ['spanner@nicinabox.com'], mail.from
+    assert_equal [ENV.fetch('FROM_EMAIL', 'noreply@localhost')], mail.from
     assert_match 'Hello', mail.body.encoded
     assert_match 'data:image/png;base64,', mail.body.encoded
   end

--- a/api/test/mailers/reminders_mailer_test.rb
+++ b/api/test/mailers/reminders_mailer_test.rb
@@ -14,7 +14,7 @@ class RemindersMailerTest < ActionMailer::TestCase
 
     assert_equal 'Reminders for Mazda', mail.subject
     assert_equal ['user1@test'], mail.to
-    assert_equal ['spanner@nicinabox.com'], mail.from
+    assert_equal [ENV.fetch('FROM_EMAIL', 'noreply@localhost')], mail.from
     assert_match 'Hello', mail.body.encoded
     assert_match 'data:image/png;base64,', mail.body.encoded
   end
@@ -27,7 +27,7 @@ class RemindersMailerTest < ActionMailer::TestCase
 
     assert_equal 'Reminders for Honda', mail.subject
     assert_equal ['user2@test'], mail.to
-    assert_equal ['spanner@nicinabox.com'], mail.from
+    assert_equal [ENV.fetch('FROM_EMAIL', 'noreply@localhost')], mail.from
     assert_match '14 days', mail.body.encoded
   end
 end

--- a/web/_content/terms.md
+++ b/web/_content/terms.md
@@ -3,7 +3,7 @@ Spanner Terms of Service and Privacy Policy
 
 ## 1. Terms
 
-By accessing the website at [https://spanner.nicinabox.com](https://spanner.nicinabox.com), you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
+By accessing the website at [{{APP_URL}}]({{APP_URL}}), you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
 
 ## 2. Use License
 

--- a/web/src/utils/getContentFile.ts
+++ b/web/src/utils/getContentFile.ts
@@ -11,5 +11,7 @@ export const getContentFile = (name: string) => {
 
 export const getHtmlFromMarkdown = (name: string) => {
     const content = getContentFile(name);
-    return marked(content);
+    const appUrl = process.env.APP_URL || 'http://localhost:3000';
+    const interpolated = content.replaceAll('{{APP_URL}}', appUrl);
+    return marked(interpolated);
 };


### PR DESCRIPTION
Replaces hardcoded `nicinabox.com` deployment references with env vars so the app is self-hostable without code changes.

## Env vars

| Variable | Purpose | Default |
|---|---|---|
| `APP_URL` | Public-facing URL (mailer links, terms page) | `http://localhost:3000` |
| `FROM_EMAIL` | Sender address for outgoing email | `noreply@localhost` |

Both are server-side only. The web terms page reads `APP_URL` at build time via `getStaticProps`, so no `NEXT_PUBLIC_` prefix is needed.

## Changes

- `api/config/environments/production.rb` — `host` from `APP_URL`
- `api/app/mailers/application_mailer.rb` — `from` from `FROM_EMAIL`
- `api/app/views/layouts/mailer.html.erb` — footer link from `APP_URL`
- `api/test/mailers/{login,reminders}_mailer_test.rb` — `from` assertions read `FROM_EMAIL` default
- `web/_content/terms.md` — replace hardcoded URL with `{{APP_URL}}` token
- `web/src/utils/getContentFile.ts` — interpolate `{{APP_URL}}` at build time

Author attribution in `README.md` and `web/package.json` is intentionally unchanged.
