### PR TITLE
Add Postmark webhook for bounce/spam handling

### DIFF
--- a/api/app/controllers/v2/postmark_controller.rb
+++ b/api/app/controllers/v2/postmark_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module V2
+  class PostmarkController < ApplicationController
+    skip_before_action :authenticate
+
+    BOUNCE_TYPES = %w[HardBounce SpamComplaint].freeze
+
+    # Public webhook receiver for all Postmark events.
+    # Postmark sends different event types to the same endpoint.
+    # Payload structure varies by event — we dispatch based on the fields present.
+    # Currently handles: bounce/spam complaints (disables reminders for the user).
+    # Other event types are accepted but ignored.
+    def webhook
+      email = webhook_email
+      return head :ok if email.blank?
+
+      disable_reminders_for(email) if bounce_event?
+
+      head :ok
+    end
+
+    private
+
+    def webhook_email
+      (params[:Email] || params[:Recipient])&.strip&.downcase
+    end
+
+    def bounce_event?
+      BOUNCE_TYPES.include?(params[:Type])
+    end
+
+    def disable_reminders_for(email)
+      user = User.find_by(email: email)
+      user&.update!(email_bounced_at: Time.zone.now)
+    end
+  end
+end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -74,7 +74,8 @@ class User < ApplicationRecord
       email: user.unconfirmed_email,
       unconfirmed_email: nil,
       email_confirmation_token: nil,
-      email_confirmation_token_valid_until: nil
+      email_confirmation_token_valid_until: nil,
+      email_bounced_at: nil
     )
     user
   end
@@ -129,6 +130,7 @@ class User < ApplicationRecord
   end
 
   def reminder_eligible?
+    return false if email_bounced_at.present?
     return false if days_since_last_seen.nil? && created_at.before?(REMINDER_CUTOFF_DAYS.days.ago)
     return false if days_since_last_seen && days_since_last_seen > REMINDER_CUTOFF_DAYS
     return true if last_reminder_sent_at.nil?

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
 
     get 'login(/:login_token)', to: 'sessions#login', as: 'login'
     get 'confirm_email(/:token)', to: 'users#confirm_email', as: 'confirm_email'
+
+    post 'webhooks/postmark', to: 'postmark#webhook'
   end
 
   scope module: :v2, constraints: ApiConstraint.new(version: 2) do

--- a/api/db/migrate/20260621000000_add_email_bounced_at_to_users.rb
+++ b/api/db/migrate/20260621000000_add_email_bounced_at_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailBouncedAtToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :email_bounced_at, :datetime
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_20_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_21_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -149,6 +149,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_20_000001) do
     t.string "email_confirmation_token"
     t.datetime "email_confirmation_token_valid_until"
     t.boolean "admin", default: false, null: false
+    t.datetime "email_bounced_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["email_confirmation_token"], name: "index_users_on_email_confirmation_token"
   end

--- a/api/test/controllers/postmark_webhook_test.rb
+++ b/api/test/controllers/postmark_webhook_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PostmarkWebhookTest < ActionDispatch::IntegrationTest
+  test 'hard bounce disables reminders for user' do
+    user = User.first
+    assert user.reminder_eligible?
+
+    post '/webhooks/postmark',
+         params: { Type: 'HardBounce', Email: user.email, BouncedAt: Time.zone.now }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :ok
+    user.reload
+    assert user.email_bounced_at.present?
+    assert_not user.reminder_eligible?
+  end
+
+  test 'spam complaint disables reminders for user' do
+    user = User.first
+
+    post '/webhooks/postmark',
+         params: { Type: 'SpamComplaint', Email: user.email, BouncedAt: Time.zone.now }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :ok
+    user.reload
+    assert user.email_bounced_at.present?
+    assert_not user.reminder_eligible?
+  end
+
+  test 'soft bounce does not disable reminders' do
+    user = User.first
+
+    post '/webhooks/postmark',
+         params: { Type: 'SoftBounce', Email: user.email, BouncedAt: Time.zone.now }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :ok
+    user.reload
+    assert user.email_bounced_at.nil?
+    assert user.reminder_eligible?
+  end
+
+  test 'unknown event type is accepted and ignored' do
+    user = User.first
+
+    post '/webhooks/postmark',
+         params: { Recipient: user.email, MessageID: '123' }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :ok
+    user.reload
+    assert user.email_bounced_at.nil?
+  end
+
+  test 'webhook with unknown email is accepted' do
+    post '/webhooks/postmark',
+         params: { Type: 'HardBounce', Email: 'nonexistent@test' }.to_json,
+         headers: { 'Content-Type' => 'application/json' }
+
+    assert_response :ok
+  end
+
+  test 'confirming email change clears bounce flag' do
+    user = User.first
+    user.update!(email_bounced_at: Time.zone.now)
+    assert_not user.reminder_eligible?
+
+    user.update!(
+      unconfirmed_email: 'newemail@test',
+      email_confirmation_token: 'token123',
+      email_confirmation_token_valid_until: 1.hour.from_now
+    )
+
+    User.confirm_email_change!('token123')
+
+    user.reload
+    assert user.email_bounced_at.nil?
+    assert user.reminder_eligible?
+  end
+end


### PR DESCRIPTION
## Postmark Webhook

Receives all Postmark event types at a single endpoint and disables reminders for users with hard bounces or spam complaints.

### What's included

- **`POST /webhooks/postmark`** — public endpoint (no auth), accepts all Postmark event types
- **HardBounce / SpamComplaint** — sets `email_bounced_at` on the user, which `reminder_eligible?` checks to suppress future reminder emails
- **SoftBounce / other events** — accepted but ignored (transient issues)
- **Email change clears bounce** — confirming an email change resets `email_bounced_at` to nil
- Works through the existing Next.js proxy (`/api/webhooks/postmark` → Rails)

### Postmark setup

1. Postmark server → Webhooks → add webhook URL: `https://spanner.nicinabox.com/api/webhooks/postmark`
2. Select events: Bounce, Spam Complaint

### Testing

- 114 tests, 0 failures
- 6 new webhook tests: hard bounce, spam complaint, soft bounce, unknown event, unknown email, email change clears bounce
- Rubocop clean