### PR TITLE
Add job to clean up unverified and inactive accounts

### DIFF
--- a/api/app/jobs/cleanup_unverified_accounts_job.rb
+++ b/api/app/jobs/cleanup_unverified_accounts_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class CleanupUnverifiedAccountsJob < ApplicationJob
+  queue_as :low_priority
+
+  # Users who entered their email but never clicked the magic link
+  NEVER_LOGGED_IN_CUTOFF = 30.days
+  # Users who logged in once but abandoned the app with no vehicles
+  INACTIVE_CUTOFF = 1.year
+
+  def perform
+    delete_never_logged_in
+    delete_bounced_accounts
+    delete_inactive_accounts
+  end
+
+  private
+
+  def delete_never_logged_in
+    User.where.missing(:sessions, :vehicles)
+        .where(users: { created_at: ...NEVER_LOGGED_IN_CUTOFF.ago })
+        .where.not(admin: true)
+        .destroy_all
+  end
+
+  def delete_bounced_accounts
+    User.where.missing(:sessions, :vehicles)
+        .where.not(email_bounced_at: nil)
+        .where.not(admin: true)
+        .destroy_all
+  end
+
+  def delete_inactive_accounts
+    inactive_ids = User.where.missing(:vehicles)
+                       .where.not(admin: true)
+                       .joins(:sessions)
+                       .where(sessions: { last_seen: ...INACTIVE_CUTOFF.ago })
+                       .pluck(:id)
+                       .uniq
+
+    User.where(id: inactive_ids).destroy_all
+  end
+end

--- a/api/app/jobs/daily_job.rb
+++ b/api/app/jobs/daily_job.rb
@@ -6,6 +6,11 @@ class DailyJob < ApplicationJob
   def perform
     upcoming_reminders
     delete_expired_sessions
+    cleanup_unverified_accounts
+  end
+
+  def cleanup_unverified_accounts
+    CleanupUnverifiedAccountsJob.perform_later
   end
 
   def upcoming_reminders

--- a/api/lib/tasks/qc.rake
+++ b/api/lib/tasks/qc.rake
@@ -36,4 +36,9 @@ namespace :qc do
   task hourly_jobs: :environment do
     HourlyJob.perform_later
   end
+
+  desc 'Run account cleanup'
+  task cleanup: :environment do
+    CleanupUnverifiedAccountsJob.perform_later
+  end
 end

--- a/api/test/jobs/cleanup_unverified_accounts_job_test.rb
+++ b/api/test/jobs/cleanup_unverified_accounts_job_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CleanupUnverifiedAccountsJobTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @admin = users(:admin)
+  end
+
+  test 'deletes never-logged-in accounts older than 30 days with no vehicles' do
+    unverified = User.create!(
+      email: 'unverified@test',
+      created_at: 31.days.ago
+    )
+
+    assert_difference -> { User.count }, -1 do
+      CleanupUnverifiedAccountsJob.new.perform
+    end
+
+    assert_not User.exists?(unverified.id)
+    assert User.exists?(@user.id)
+  end
+
+  test 'does not delete never-logged-in accounts newer than 30 days' do
+    new_user = User.create!(
+      email: 'newuser@test',
+      created_at: 10.days.ago
+    )
+
+    CleanupUnverifiedAccountsJob.new.perform
+
+    assert User.exists?(new_user.id)
+  end
+
+  test 'does not delete accounts with vehicles even if never logged in' do
+    user_with_vehicle = User.create!(
+      email: 'hasvehicle@test',
+      created_at: 60.days.ago
+    )
+    user_with_vehicle.vehicles.create!(name: 'My Car')
+
+    CleanupUnverifiedAccountsJob.new.perform
+
+    assert User.exists?(user_with_vehicle.id)
+  end
+
+  test 'does not delete admin accounts' do
+    admin = User.create!(
+      email: 'admin2@test',
+      created_at: 60.days.ago,
+      admin: true
+    )
+
+    CleanupUnverifiedAccountsJob.new.perform
+
+    assert User.exists?(admin.id)
+  end
+
+  test 'deletes bounced accounts with no vehicles and no sessions' do
+    bounced = User.create!(
+      email: 'bounced@test',
+      created_at: 5.days.ago,
+      email_bounced_at: Time.zone.now
+    )
+
+    assert_difference -> { User.count }, -1 do
+      CleanupUnverifiedAccountsJob.new.perform
+    end
+
+    assert_not User.exists?(bounced.id)
+  end
+
+  test 'deletes inactive accounts with no vehicles last seen over 1 year ago' do
+    inactive = User.create!(
+      email: 'inactive@test',
+      created_at: 2.years.ago
+    )
+    inactive.sessions.create!(
+      ip: '1.1.1.1',
+      auth_token: 'tok123',
+      auth_token_valid_until: 2.years.from_now,
+      last_seen: 2.years.ago
+    )
+
+    assert_difference -> { User.count }, -1 do
+      CleanupUnverifiedAccountsJob.new.perform
+    end
+
+    assert_not User.exists?(inactive.id)
+  end
+
+  test 'does not delete inactive accounts with vehicles' do
+    inactive_with_vehicle = User.create!(
+      email: 'inactivevehicle@test',
+      created_at: 2.years.ago
+    )
+    inactive_with_vehicle.sessions.create!(
+      ip: '1.1.1.1',
+      auth_token: 'tok456',
+      auth_token_valid_until: 2.years.from_now,
+      last_seen: 2.years.ago
+    )
+    inactive_with_vehicle.vehicles.create!(name: 'Old Car')
+
+    CleanupUnverifiedAccountsJob.new.perform
+
+    assert User.exists?(inactive_with_vehicle.id)
+  end
+
+  test 'deletes associated sessions when cleaning up' do
+    unverified = User.create!(
+      email: 'withsession@test',
+      created_at: 2.years.ago
+    )
+    unverified.sessions.create!(
+      ip: '1.1.1.1',
+      auth_token: 'tok789',
+      auth_token_valid_until: 2.years.from_now,
+      last_seen: 2.years.ago
+    )
+    session_id = unverified.sessions.first.id
+
+    CleanupUnverifiedAccountsJob.new.perform
+
+    assert_not User.exists?(unverified.id)
+    assert_not Session.exists?(session_id)
+  end
+end


### PR DESCRIPTION
## Account Cleanup

Runs daily as part of `DailyJob` to delete three categories of abandoned accounts.

### Cleanup categories

| Category | Condition | Cutoff |
|---|---|---|
| Never logged in | No sessions, no vehicles | Created 30+ days ago |
| Bounced email | Email bounced, no sessions, no vehicles | Any age |
| Inactive | Last seen 1+ year ago, no vehicles | - |

Admin accounts are always protected. Cascading deletes handle sessions, vehicles, records, service schedules, reminders, and attachments.

### Current impact

~449 accounts would be cleaned up on first run (441 never-logged-in, 8 inactive).

### Files

- `app/jobs/cleanup_unverified_accounts_job.rb` — job with three targeted queries
- `app/jobs/daily_job.rb` — enqueues cleanup as part of daily run
- `lib/tasks/qc.rake` — adds `rails qc:cleanup` for manual runs

### Testing

- 122 tests, 0 failures
- 8 new tests covering all three categories plus edge cases (vehicles protect accounts, admin protected, cascade)
- Rubocop clean