### PR TITLE
Add notification dispatcher with EmailChannel and WebhookChannel

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -44,5 +44,9 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
+group :test do
+  gem 'webmock'
+end
+
 # Include timezone data for all platforms (required for Railway)
 gem 'tzinfo-data'

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
+    crack (1.0.1)
+      bigdecimal
+      rexml
     crass (1.0.6)
     css_parser (1.21.1)
       addressable
@@ -147,6 +150,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashdiff (1.2.1)
     htmlentities (4.3.4)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -291,6 +295,7 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
+    rexml (3.4.4)
     rubocop (1.80.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -339,6 +344,10 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -386,6 +395,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data
   virtus
+  webmock
 
 RUBY VERSION
    ruby 3.4.6p54

--- a/api/app/controllers/v2/service_schedules_controller.rb
+++ b/api/app/controllers/v2/service_schedules_controller.rb
@@ -13,14 +13,14 @@ module V2
     def create
       schedule = schedules.build(schedule_params)
       schedule.save!
-      schedule.generate_reminder
+      schedule.recalculate_next_due
       render json: schedule
     end
 
     def update
       schedule = schedules.find(params[:id])
       schedule.update!(schedule_params)
-      schedule.generate_reminder
+      schedule.recalculate_next_due
       render json: schedule
     end
 

--- a/api/app/jobs/daily_job.rb
+++ b/api/app/jobs/daily_job.rb
@@ -5,6 +5,7 @@ class DailyJob < ApplicationJob
 
   def perform
     upcoming_reminders
+    upcoming_schedules
     delete_expired_sessions
     cleanup_unverified_accounts
   end
@@ -17,11 +18,26 @@ class DailyJob < ApplicationJob
     reminders = reminders_on(2.weeks.from_now)
     users = reminders.group_by { |r| r.vehicle.user }
 
-    users.each do |user, reminders|
+    users.each do |user, user_reminders|
       next unless user.reminder_eligible?
 
-      RemindersMailer.reminder_upcoming(user, reminders).deliver_now
+      NotificationDispatcher.dispatch(:reminder_upcoming, user: user, reminders: user_reminders)
       user.record_reminder_sent!
+    end
+  end
+
+  def upcoming_schedules
+    schedules = ServiceSchedule.where(
+      next_due_date: Time.zone.today..2.weeks.from_now,
+      enabled: true
+    ).includes(:vehicle, :classification)
+
+    by_user = schedules.group_by { |s| s.vehicle.user }
+
+    by_user.each do |user, user_schedules|
+      next unless user.reminder_eligible?
+
+      NotificationDispatcher.dispatch(:schedule_due_upcoming, user: user, schedules: user_schedules)
     end
   end
 

--- a/api/app/jobs/hourly_job.rb
+++ b/api/app/jobs/hourly_job.rb
@@ -20,16 +20,30 @@ class HourlyJob < ApplicationJob
       User.where(time_zone_offset: time_zone_offset).find_each do |user|
         next unless user.reminder_eligible?
 
-        reminders = user.reminders.where(reminder_date: date.all_day)
-        reminders = reminders.select do |r|
-          r.vehicle.preferences.send_reminder_emails
-        end
-
-        next if reminders.empty?
-
-        RemindersMailer.reminder_today(user, reminders).deliver_now
-        user.record_reminder_sent!
+        dispatch_manual_reminders(user, date)
+        dispatch_due_schedules(user, date)
       end
     end
+  end
+
+  private
+
+  def dispatch_manual_reminders(user, date)
+    reminders = user.reminders.where(reminder_date: date.all_day)
+    reminders = reminders.select { |r| r.vehicle.preferences.send_reminder_emails }
+    return if reminders.empty?
+
+    NotificationDispatcher.dispatch(:reminder_today, user: user, reminders: reminders)
+    user.record_reminder_sent!
+  end
+
+  def dispatch_due_schedules(user, date)
+    schedules = ServiceSchedule.joins(:vehicle)
+                               .where(vehicles: { user_id: user.id })
+                               .where(next_due_date: date.all_day, enabled: true)
+                               .includes(:vehicle, :classification)
+    return if schedules.empty?
+
+    NotificationDispatcher.dispatch(:schedule_due_today, user: user, schedules: schedules)
   end
 end

--- a/api/app/models/record.rb
+++ b/api/app/models/record.rb
@@ -67,6 +67,6 @@ class Record < ApplicationRecord
 
   def advance_matching_service_schedules
     matching_schedules = vehicle.service_schedules.where(classification_id: classifications.pluck(:id))
-    matching_schedules.each(&:generate_reminder)
+    matching_schedules.each(&:recalculate_next_due)
   end
 end

--- a/api/app/models/service_schedule.rb
+++ b/api/app/models/service_schedule.rb
@@ -3,7 +3,6 @@
 class ServiceSchedule < ApplicationRecord
   belongs_to :vehicle
   belongs_to :classification
-  has_one :reminder, dependent: :destroy
 
   # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
   validates :vehicle, presence: true
@@ -11,36 +10,19 @@ class ServiceSchedule < ApplicationRecord
   # rubocop:enable Rails/RedundantPresenceValidationOnBelongsTo
   validate :at_least_one_interval
 
-  def generate_reminder
-    return destroy_reminder unless enabled?
+  def recalculate_next_due
+    unless enabled?
+      update!(next_due_date: nil, next_due_mileage: nil)
+      return
+    end
 
     last_record = last_matching_record
 
-    reminder_data = {
-      vehicle: vehicle,
-      service_schedule: self,
-      notes: classification.name
-    }
+    attrs = {}
+    attrs[:next_due_mileage] = next_mileage(last_record) if mileage_interval.present?
+    attrs[:next_due_date] = next_date(last_record) if month_interval.present?
 
-    if mileage_interval.present?
-      reminder_data[:mileage] = next_mileage(last_record)
-      reminder_data[:reminder_type] = 'mileage'
-    end
-
-    if month_interval.present?
-      reminder_data[:date] = next_date(last_record)
-      reminder_data[:reminder_type] = if mileage_interval.present?
-                                        'date_or_mileage'
-                                      else
-                                        'date'
-                                      end
-    end
-
-    if reminder
-      reminder.update!(reminder_data)
-    else
-      Reminder.create!(reminder_data)
-    end
+    update!(attrs)
   end
 
   def complete!(notes: nil, date: nil, mileage: nil)
@@ -51,7 +33,7 @@ class ServiceSchedule < ApplicationRecord
     )
 
     update!(last_completed_record_id: record.id)
-    generate_reminder
+    recalculate_next_due
     record
   end
 
@@ -63,11 +45,6 @@ class ServiceSchedule < ApplicationRecord
     errors.add(:base, 'at least one of mileage_interval or month_interval must be present')
   end
 
-  def destroy_reminder
-    reminder&.destroy
-    association(:reminder).reset
-  end
-
   def last_matching_record
     vehicle.records
            .joins(:classifications)
@@ -77,12 +54,12 @@ class ServiceSchedule < ApplicationRecord
   end
 
   def next_mileage(last_record)
-    base_mileage = last_record&.mileage || vehicle.estimated_mileage || 0
-    base_mileage + mileage_interval
+    base = last_record&.mileage || vehicle.estimated_mileage || 0
+    base + mileage_interval
   end
 
   def next_date(last_record)
-    base_date = last_record&.date || Time.zone.today
-    base_date + month_interval.months
+    base = last_record&.date || Time.zone.today
+    base + month_interval.months
   end
 end

--- a/api/app/serializers/service_schedule_serializer.rb
+++ b/api/app/serializers/service_schedule_serializer.rb
@@ -4,12 +4,4 @@ class ServiceScheduleSerializer < ActiveModel::Serializer
   attributes :id, :vehicle_id, :classification_id, :mileage_interval,
              :month_interval, :notes, :enabled, :last_completed_record_id,
              :next_due_date, :next_due_mileage, :created_at, :updated_at
-
-  def next_due_date
-    object.reminder&.date
-  end
-
-  def next_due_mileage
-    object.reminder&.mileage
-  end
 end

--- a/api/app/services/channels/email_channel.rb
+++ b/api/app/services/channels/email_channel.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class EmailChannel
+  def self.available?
+    ENV['POSTMARK_API_KEY'].present? || ENV['SMTP_HOST'].present?
+  end
+
+  def self.deliver(event, user:, reminders: nil, schedules: nil)
+    case event
+    when :reminder_today
+      RemindersMailer.reminder_today(user, reminders).deliver_now
+    when :reminder_upcoming
+      RemindersMailer.reminder_upcoming(user, reminders).deliver_now
+    when :schedule_due_today
+      RemindersMailer.reminder_today(user, schedules_as_reminders(schedules)).deliver_now
+    when :schedule_due_upcoming
+      RemindersMailer.reminder_upcoming(user, schedules_as_reminders(schedules)).deliver_now
+    end
+  end
+
+  def self.schedules_as_reminders(schedules)
+    schedules.map { |s| ScheduleReminderAdapter.new(s) }
+  end
+  private_class_method :schedules_as_reminders
+end

--- a/api/app/services/channels/schedule_reminder_adapter.rb
+++ b/api/app/services/channels/schedule_reminder_adapter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Adapts a ServiceSchedule to present the same interface as a Reminder
+# so existing mailer templates work unchanged.
+class ScheduleReminderAdapter
+  delegate :vehicle, to: :@schedule
+
+  def initialize(schedule)
+    @schedule = schedule
+  end
+
+  def notes
+    @schedule.notes.presence || @schedule.classification.name
+  end
+
+  def reminder_date
+    @schedule.next_due_date
+  end
+
+  def mileage
+    @schedule.next_due_mileage
+  end
+
+  def date
+    @schedule.next_due_date
+  end
+end

--- a/api/app/services/channels/webhook_channel.rb
+++ b/api/app/services/channels/webhook_channel.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+class WebhookChannel
+  TIMEOUT = 5
+
+  def self.available?
+    ENV['NOTIFICATION_WEBHOOK_URL'].present?
+  end
+
+  def self.deliver(event, user:, reminders: nil, schedules: nil)
+    uri = URI(ENV.fetch('NOTIFICATION_WEBHOOK_URL', nil))
+
+    payload = base_payload(event, user)
+
+    if schedules
+      payload[:schedules] = schedules.map { |s| schedule_payload(s) }
+    else
+      payload[:reminders] = Array(reminders).map { |r| reminder_payload(r) }
+    end
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+    http.open_timeout = TIMEOUT
+    http.read_timeout = TIMEOUT
+
+    request = Net::HTTP::Post.new(uri.path.presence || '/', 'Content-Type' => 'application/json')
+    request.body = payload.to_json
+
+    http.request(request)
+  end
+
+  def self.base_payload(event, user)
+    {
+      event: event,
+      timestamp: Time.zone.now.iso8601,
+      user: { email: user.email }
+    }
+  end
+  private_class_method :base_payload
+
+  def self.reminder_payload(reminder)
+    {
+      notes: reminder.notes,
+      vehicle: reminder.vehicle.name,
+      reminder_date: reminder.reminder_date,
+      mileage: reminder.mileage
+    }
+  end
+  private_class_method :reminder_payload
+
+  def self.schedule_payload(schedule)
+    {
+      classification: schedule.classification.name,
+      vehicle: schedule.vehicle.name,
+      next_due_date: schedule.next_due_date,
+      next_due_mileage: schedule.next_due_mileage,
+      notes: schedule.notes
+    }
+  end
+  private_class_method :schedule_payload
+end

--- a/api/app/services/notification_dispatcher.rb
+++ b/api/app/services/notification_dispatcher.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class NotificationDispatcher
+  CHANNELS = [EmailChannel, WebhookChannel].freeze
+
+  def self.dispatch(event, **)
+    CHANNELS.each do |channel|
+      next unless channel.available?
+
+      channel.deliver(event, **)
+    rescue StandardError => e
+      Rails.logger.error("#{channel}: #{e.message}")
+    end
+  end
+end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -31,6 +31,7 @@ module SpannerApi
     config.api_only = true
 
     config.autoload_paths << Rails.root.join('lib')
+    config.autoload_paths << Rails.root.join('app/services/channels')
 
     config.active_job.queue_adapter = :queue_classic
     config.action_mailer.deliver_later_queue_name = 'default'

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -59,11 +59,26 @@ Rails.application.configure do
 
   config.action_mailer.asset_host = api_host
 
-  config.action_mailer.delivery_method = :postmark
+  # SMTP as fallback for self-hosted (set first, may be overridden by Postmark)
+  if ENV['SMTP_HOST'].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address: ENV['SMTP_HOST'],
+      port: ENV.fetch('SMTP_PORT', 587).to_i,
+      user_name: ENV.fetch('SMTP_USERNAME', nil),
+      password: ENV.fetch('SMTP_PASSWORD', nil),
+      authentication: :plain,
+      enable_starttls_auto: true
+    }
+  end
 
-  config.action_mailer.postmark_settings = {
-    api_token: ENV.fetch('POSTMARK_API_KEY', nil)
-  }
+  # Postmark takes priority — overwrites SMTP if both are configured
+  if ENV['POSTMARK_API_KEY'].present?
+    config.action_mailer.delivery_method = :postmark
+    config.action_mailer.postmark_settings = {
+      api_token: ENV['POSTMARK_API_KEY']
+    }
+  end
 
   config.action_mailer.default_url_options = {
     host: host

--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -36,6 +36,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Make EmailChannel available in tests (actual delivery uses :test adapter)
+  ENV['POSTMARK_API_KEY'] ||= 'test-key'
+
   # Use the test queue adapter so Active Job jobs can be performed inline
   # during tests (e.g. perform_enqueued_jobs).
   config.active_job.queue_adapter = :test

--- a/api/db/migrate/20260622000000_add_next_due_to_service_schedules.rb
+++ b/api/db/migrate/20260622000000_add_next_due_to_service_schedules.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddNextDueToServiceSchedules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :service_schedules, :next_due_date, :date
+    add_column :service_schedules, :next_due_mileage, :integer
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_21_000000) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_22_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -117,6 +117,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_21_000000) do
     t.bigint "last_completed_record_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.date "next_due_date"
+    t.integer "next_due_mileage"
     t.index ["classification_id"], name: "index_service_schedules_on_classification_id"
     t.index ["last_completed_record_id"], name: "index_service_schedules_on_last_completed_record_id"
     t.index ["vehicle_id", "classification_id"], name: "index_service_schedules_on_vehicle_id_and_classification_id", unique: true

--- a/api/test/controllers/service_schedules_controller_test.rb
+++ b/api/test/controllers/service_schedules_controller_test.rb
@@ -43,7 +43,7 @@ class ServiceSchedulesControllerTest < ActionDispatch::IntegrationTest
 
     schedule = ServiceSchedule.find(response_body['id'])
     assert_equal 7500, schedule.mileage_interval
-    assert schedule.reminder.present?
+    assert schedule.reload.next_due_mileage.present?
   end
 
   test 'update modifies a schedule and regenerates reminder' do
@@ -56,20 +56,15 @@ class ServiceSchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 7500, @schedule.mileage_interval
   end
 
-  test 'destroy removes schedule and linked reminder' do
-    @schedule.generate_reminder
-    reminder_id = @schedule.reminder.id
-
+  test 'destroy removes schedule' do
     delete vehicle_service_schedule_url(@vehicle, @schedule),
            headers: http_options(@session.auth_token)[:headers]
     assert_response :success
-
     assert_not ServiceSchedule.exists?(@schedule.id)
-    assert_not Reminder.exists?(reminder_id)
   end
 
   test 'complete creates a record and advances schedule' do
-    @schedule.generate_reminder
+    @schedule.recalculate_next_due
 
     assert_difference -> { @vehicle.records.count }, 1 do
       post complete_vehicle_service_schedule_url(@vehicle, @schedule),
@@ -79,11 +74,11 @@ class ServiceSchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
 
     @schedule.reload
-    assert_equal 57_000, @schedule.reminder.mileage
+    assert_equal 57_000, @schedule.reload.next_due_mileage
   end
 
   test 'complete with no overrides uses defaults' do
-    @schedule.generate_reminder
+    @schedule.recalculate_next_due
 
     post complete_vehicle_service_schedule_url(@vehicle, @schedule),
          headers: http_options(@session.auth_token)[:headers]

--- a/api/test/controllers/service_schedules_controller_test.rb
+++ b/api/test/controllers/service_schedules_controller_test.rb
@@ -28,7 +28,7 @@ class ServiceSchedulesControllerTest < ActionDispatch::IntegrationTest
     assert_equal 5000, response_body['mileage_interval']
   end
 
-  test 'create creates a schedule and generates reminder' do
+  test 'create creates a schedule and recalculates next due' do
     @other_classification = Classification.find_by!(key: 'tire_rotation')
 
     assert_difference -> { ServiceSchedule.count }, 1 do
@@ -46,7 +46,7 @@ class ServiceSchedulesControllerTest < ActionDispatch::IntegrationTest
     assert schedule.reload.next_due_mileage.present?
   end
 
-  test 'update modifies a schedule and regenerates reminder' do
+  test 'update modifies a schedule and recalculates next due' do
     put vehicle_service_schedule_url(@vehicle, @schedule),
         params: { service_schedule: { mileage_interval: 7500 } },
         headers: http_options(@session.auth_token)[:headers]

--- a/api/test/models/service_schedule_test.rb
+++ b/api/test/models/service_schedule_test.rb
@@ -71,21 +71,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
     assert schedule.enabled
   end
 
-  test 'has_one reminder association' do
-    schedule = ServiceSchedule.create!(
-      vehicle: @vehicle,
-      classification: @classification,
-      mileage_interval: 5000
-    )
-    reminder = Reminder.create!(
-      vehicle: @vehicle,
-      notes: @classification.name,
-      service_schedule: schedule
-    )
-    assert_equal reminder, schedule.reminder
-  end
-
-  test 'generate_reminder from mileage interval with matching record' do
+  test 'recalculate_next_due from mileage interval with matching record' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     vehicle.records.create!(
       date: 30.days.ago,
@@ -98,15 +84,13 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert schedule.reminder.present?
-    assert_equal 55_000, schedule.reminder.mileage
-    assert_equal 'mileage', schedule.reminder.reminder_type
-    assert_equal schedule, schedule.reminder.service_schedule
+    assert schedule.reload.next_due_mileage.present?
+    assert_equal 55_000, schedule.reload.next_due_mileage
   end
 
-  test 'generate_reminder from mileage interval with no matching record uses estimated mileage' do
+  test 'recalculate_next_due from mileage interval with no matching record uses estimated mileage' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
 
     schedule = ServiceSchedule.create!(
@@ -114,13 +98,12 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert schedule.reminder.present?
-    assert_equal 'mileage', schedule.reminder.reminder_type
+    assert schedule.reload.next_due_mileage.present?
   end
 
-  test 'generate_reminder from month interval with matching record' do
+  test 'recalculate_next_due from month interval with matching record' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     vehicle.records.create!(
       date: 30.days.ago,
@@ -133,14 +116,13 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       month_interval: 6
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert schedule.reminder.present?
-    assert_equal 'date', schedule.reminder.reminder_type
-    assert_equal 30.days.ago.to_date + 6.months, schedule.reminder.date.to_date
+    assert schedule.reload.next_due_date.present?
+    assert_equal 30.days.ago.to_date + 6.months, schedule.reload.next_due_date
   end
 
-  test 'generate_reminder with both intervals creates date_or_mileage reminder' do
+  test 'recalculate_next_due with both intervals sets both next_due fields' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     vehicle.records.create!(
       date: 30.days.ago,
@@ -154,15 +136,14 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       mileage_interval: 5000,
       month_interval: 12
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert schedule.reminder.present?
-    assert_equal 'date_or_mileage', schedule.reminder.reminder_type
-    assert_equal 55_000, schedule.reminder.mileage
-    assert_equal 30.days.ago.to_date + 12.months, schedule.reminder.date.to_date
+    assert schedule.reload.next_due_mileage.present?
+    assert_equal 55_000, schedule.reload.next_due_mileage
+    assert_equal 30.days.ago.to_date + 12.months, schedule.reload.next_due_date
   end
 
-  test 'generate_reminder updates existing reminder instead of creating duplicate' do
+  test 'recalculate_next_due updates next_due_mileage after new matching record' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     vehicle.records.create!(
       date: 30.days.ago,
@@ -175,37 +156,36 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
-    original_reminder_id = schedule.reminder.id
+    schedule.recalculate_next_due
 
     vehicle.records.create!(
       date: Time.zone.today,
       notes: 'Oil change',
       mileage: 53_000
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert_equal original_reminder_id, schedule.reminder.id
-    assert_equal 58_000, schedule.reminder.mileage
+    assert_equal 58_000, schedule.reload.next_due_mileage
   end
 
-  test 'generate_reminder when disabled destroys existing reminder' do
+  test 'recalculate_next_due when disabled clears next_due fields' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     schedule = ServiceSchedule.create!(
       vehicle: vehicle,
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
-    assert schedule.reminder.present?
+    schedule.recalculate_next_due
+    assert schedule.reload.next_due_mileage.present?
 
     schedule.update!(enabled: false)
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
-    assert_nil schedule.reminder
+    assert_nil schedule.reload.next_due_date
+    assert_nil schedule.reload.next_due_mileage
   end
 
-  test 'complete! creates a record and advances reminder' do
+  test 'complete! creates a record and advances next_due' do
     vehicle = Vehicle.create!(name: 'Test Car', user: @user)
     vehicle.records.create!(
       date: 30.days.ago,
@@ -218,7 +198,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
     assert_difference -> { vehicle.records.count }, 1 do
       schedule.complete!
@@ -227,7 +207,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
     last_record = vehicle.records.reorder(date: :desc).first
     assert_equal @classification.name, last_record.notes
     assert_equal last_record.id, schedule.reload.last_completed_record_id
-    assert_equal 55_000, schedule.reminder.mileage
+    assert_equal 55_000, schedule.reload.next_due_mileage
   end
 
   test 'complete! with override params' do
@@ -243,7 +223,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
     schedule.complete!(notes: 'Synthetic oil change', date: 3.days.ago, mileage: 52_000)
 
@@ -251,7 +231,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
     assert_equal 'Synthetic oil change', last_record.notes
     assert_equal 3.days.ago.to_date, last_record.date.to_date
     assert_equal 52_000, last_record.mileage
-    assert_equal 57_000, schedule.reminder.mileage
+    assert_equal 57_000, schedule.reload.next_due_mileage
   end
 
   test 'complete! defaults mileage to estimated mileage' do
@@ -261,7 +241,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       month_interval: 12
     )
-    schedule.generate_reminder
+    schedule.recalculate_next_due
 
     schedule.complete!
 
@@ -282,8 +262,8 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
-    assert_equal 55_000, schedule.reminder.mileage
+    schedule.recalculate_next_due
+    assert_equal 55_000, schedule.reload.next_due_mileage
 
     vehicle.records.create!(
       date: Time.zone.today,
@@ -292,7 +272,7 @@ class ServiceScheduleTest < ActiveSupport::TestCase
     )
 
     schedule.reload
-    assert_equal 58_000, schedule.reminder.mileage
+    assert_equal 58_000, schedule.reload.next_due_mileage
   end
 
   test 'does not advance schedules when record does not match classification' do
@@ -308,8 +288,8 @@ class ServiceScheduleTest < ActiveSupport::TestCase
       classification: @classification,
       mileage_interval: 5000
     )
-    schedule.generate_reminder
-    original_mileage = schedule.reminder.mileage
+    schedule.recalculate_next_due
+    original_mileage = schedule.reload.next_due_mileage
 
     vehicle.records.create!(
       date: Time.zone.today,
@@ -318,6 +298,6 @@ class ServiceScheduleTest < ActiveSupport::TestCase
     )
 
     schedule.reload
-    assert_equal original_mileage, schedule.reminder.mileage
+    assert_equal original_mileage, schedule.reload.next_due_mileage
   end
 end

--- a/api/test/services/notification_dispatcher_test.rb
+++ b/api/test/services/notification_dispatcher_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
+require 'webmock/minitest'
 
 class EmailChannelTest < ActiveSupport::TestCase
   setup do
@@ -55,6 +56,72 @@ class EmailChannelTest < ActiveSupport::TestCase
   test 'delivers schedule_due_upcoming via RemindersMailer' do
     assert_emails 1 do
       EmailChannel.deliver(:schedule_due_upcoming, user: @user, schedules: @schedules)
+    end
+  end
+
+  private
+
+  def with_env(vars)
+    originals = vars.to_h { |k, _| [k.to_s, ENV.fetch(k.to_s, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
+    yield
+  ensure
+    originals.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+end
+
+class WebhookChannelTest < ActiveSupport::TestCase
+  setup do
+    @user = User.first
+    @reminders = @user.reminders.to_a
+    @schedule = ServiceSchedule.new(
+      vehicle: @user.vehicles.first,
+      classification: Classification.find_by!(key: 'oil_change'),
+      mileage_interval: 5000,
+      next_due_mileage: 55_000,
+      next_due_date: 3.months.from_now.to_date
+    )
+  end
+
+  test 'available? returns true when NOTIFICATION_WEBHOOK_URL set' do
+    with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+      assert WebhookChannel.available?
+    end
+  end
+
+  test 'available? returns false when not set' do
+    with_env('NOTIFICATION_WEBHOOK_URL' => nil) do
+      assert_not WebhookChannel.available?
+    end
+  end
+
+  test 'sends reminder payload to webhook URL' do
+    stub_request(:post, 'https://hooks.example.com')
+
+    with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+      WebhookChannel.deliver(:reminder_today, user: @user, reminders: @reminders)
+    end
+
+    assert_requested(:post, 'https://hooks.example.com') do |req|
+      body = JSON.parse(req.body)
+      body['event'] == 'reminder_today' &&
+        body['user']['email'] == @user.email &&
+        body.key?('reminders')
+    end
+  end
+
+  test 'sends schedule payload with schedules key' do
+    stub_request(:post, 'https://hooks.example.com')
+
+    with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+      WebhookChannel.deliver(:schedule_due_today, user: @user, schedules: [@schedule])
+    end
+
+    assert_requested(:post, 'https://hooks.example.com') do |req|
+      body = JSON.parse(req.body)
+      body['event'] == 'schedule_due_today' &&
+        body.key?('schedules') &&
+        !body.key?('reminders')
     end
   end
 

--- a/api/test/services/notification_dispatcher_test.rb
+++ b/api/test/services/notification_dispatcher_test.rb
@@ -2,6 +2,7 @@
 
 require 'test_helper'
 require 'webmock/minitest'
+require 'minitest/mock'
 
 class EmailChannelTest < ActiveSupport::TestCase
   setup do
@@ -129,6 +130,90 @@ class WebhookChannelTest < ActiveSupport::TestCase
 
   def with_env(vars)
     originals = vars.to_h { |k, _| [k.to_s, ENV.fetch(k.to_s, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
+    yield
+  ensure
+    originals.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+end
+
+class NotificationDispatcherTest < ActiveSupport::TestCase
+  setup do
+    @user = User.first
+    @reminders = @user.reminders.to_a
+  end
+
+  test 'dispatches to email channel when available' do
+    EmailChannel.stub(:available?, true) do
+      WebhookChannel.stub(:available?, false) do
+        assert_emails 1 do
+          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+        end
+      end
+    end
+  end
+
+  test 'dispatches to webhook channel when available' do
+    stub_request(:post, 'https://hooks.example.com')
+
+    EmailChannel.stub(:available?, false) do
+      WebhookChannel.stub(:available?, true) do
+        with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+        end
+      end
+    end
+
+    assert_requested :post, 'https://hooks.example.com'
+  end
+
+  test 'dispatches to both channels when both available' do
+    stub_request(:post, 'https://hooks.example.com')
+
+    EmailChannel.stub(:available?, true) do
+      WebhookChannel.stub(:available?, true) do
+        with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+          assert_emails 1 do
+            NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+          end
+        end
+      end
+    end
+
+    assert_requested :post, 'https://hooks.example.com'
+  end
+
+  test 'skips unavailable channels' do
+    EmailChannel.stub(:available?, false) do
+      WebhookChannel.stub(:available?, false) do
+        assert_emails 0 do
+          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+        end
+      end
+    end
+  end
+
+  test 'continues to next channel if one raises' do
+    stub_request(:post, 'https://hooks.example.com')
+
+    EmailChannel.stub(:available?, true) do
+      WebhookChannel.stub(:available?, true) do
+        with_env('NOTIFICATION_WEBHOOK_URL' => 'https://hooks.example.com') do
+          # Stub deliver to raise, then verify webhook still fires
+          EmailChannel.stub(:deliver, ->(*, **) { raise 'email down' }) do
+            NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+          end
+        end
+      end
+    end
+
+    assert_requested :post, 'https://hooks.example.com'
+  end
+
+  private
+
+  def with_env(vars)
+    originals = vars.transform_keys(&:to_s).transform_values { |_| ENV[_] }
     vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
     yield
   ensure

--- a/api/test/services/notification_dispatcher_test.rb
+++ b/api/test/services/notification_dispatcher_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class EmailChannelTest < ActiveSupport::TestCase
+  setup do
+    @user = User.first
+    @reminders = @user.reminders.to_a
+    @schedule = ServiceSchedule.new(
+      vehicle: @user.vehicles.first,
+      classification: Classification.find_by!(key: 'oil_change'),
+      mileage_interval: 5000,
+      next_due_mileage: 55_000,
+      next_due_date: 3.months.from_now.to_date
+    )
+    @schedules = [@schedule]
+  end
+
+  test 'available? returns true when POSTMARK_API_KEY set' do
+    with_env('POSTMARK_API_KEY' => 'key', 'SMTP_HOST' => nil) do
+      assert EmailChannel.available?
+    end
+  end
+
+  test 'available? returns true when SMTP_HOST set' do
+    with_env('POSTMARK_API_KEY' => nil, 'SMTP_HOST' => 'smtp.example.com') do
+      assert EmailChannel.available?
+    end
+  end
+
+  test 'available? returns false when neither set' do
+    with_env('POSTMARK_API_KEY' => nil, 'SMTP_HOST' => nil) do
+      assert_not EmailChannel.available?
+    end
+  end
+
+  test 'delivers reminder_today via RemindersMailer' do
+    assert_emails 1 do
+      EmailChannel.deliver(:reminder_today, user: @user, reminders: @reminders)
+    end
+  end
+
+  test 'delivers reminder_upcoming via RemindersMailer' do
+    assert_emails 1 do
+      EmailChannel.deliver(:reminder_upcoming, user: @user, reminders: @reminders)
+    end
+  end
+
+  test 'delivers schedule_due_today via RemindersMailer' do
+    assert_emails 1 do
+      EmailChannel.deliver(:schedule_due_today, user: @user, schedules: @schedules)
+    end
+  end
+
+  test 'delivers schedule_due_upcoming via RemindersMailer' do
+    assert_emails 1 do
+      EmailChannel.deliver(:schedule_due_upcoming, user: @user, schedules: @schedules)
+    end
+  end
+
+  private
+
+  def with_env(vars)
+    originals = vars.to_h { |k, _| [k.to_s, ENV.fetch(k.to_s, nil)] }
+    vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
+    yield
+  ensure
+    originals.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+  end
+end

--- a/api/test/services/notification_dispatcher_test.rb
+++ b/api/test/services/notification_dispatcher_test.rb
@@ -213,7 +213,7 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
   private
 
   def with_env(vars)
-    originals = vars.transform_keys(&:to_s).transform_values { |_| ENV[_] }
+    originals = vars.transform_keys(&:to_s).transform_values { |k| ENV.fetch(k, nil) }
     vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
     yield
   ensure


### PR DESCRIPTION
## Notification Dispatcher

Replaces direct mailer calls in jobs with a NotificationDispatcher that routes notifications through configured delivery channels. Also migrates service schedules from reminder-based to column-based next-due tracking.

### Part A: Service Schedule Migration

- Removed `has_one :reminder` from ServiceSchedule — schedules now store `next_due_date` and `next_due_mileage` directly as columns
- Renamed `generate_reminder` → `recalculate_next_due` — updates schedule columns instead of creating Reminder records
- Updated serializer, controller, and record auto-advance callback

### Part B: Notification Dispatcher

- **NotificationDispatcher** — iterates available channels, delivers to all configured, rescues errors per-channel
- **EmailChannel** — wraps RemindersMailer, supports Postmark (priority) or SMTP (fallback). Includes ScheduleReminderAdapter to adapt schedules for existing mailer templates
- **WebhookChannel** — HTTP POST with JSON payload to `NOTIFICATION_WEBHOOK_URL`. Separate payload keys for reminders vs schedules
- **SMTP config** — reads from `SMTP_HOST`/`SMTP_PORT`/`SMTP_USERNAME`/`SMTP_PASSWORD` env vars. Postmark takes priority if both configured
- **Job wiring** — HourlyJob and DailyJob use dispatcher for both manual reminders and service schedules

### Testing

- 137 tests, 0 failures
- 16 new notification dispatcher tests (EmailChannel, WebhookChannel, NotificationDispatcher)
- Rubocop clean

### Files

**Created:**
- `api/app/services/notification_dispatcher.rb`
- `api/app/services/channels/email_channel.rb`
- `api/app/services/channels/webhook_channel.rb`
- `api/app/services/channels/schedule_reminder_adapter.rb`
- `api/db/migrate/20260622000000_add_next_due_to_service_schedules.rb`
- `api/test/services/notification_dispatcher_test.rb`

**Modified:**
- `api/app/models/service_schedule.rb` — removed reminder, renamed to recalculate_next_due
- `api/app/models/record.rb` — updated callback
- `api/app/serializers/service_schedule_serializer.rb` — read columns directly
- `api/app/controllers/v2/service_schedules_controller.rb` — use recalculate_next_due
- `api/app/jobs/hourly_job.rb` — use dispatcher
- `api/app/jobs/daily_job.rb` — use dispatcher
- `api/config/environments/production.rb` — SMTP config
- `api/Gemfile` — added webmock for tests