### PR TITLE
Add file attachments to service records

### DIFF
--- a/web-v4/src/lib/components/HistoryTable.svelte
+++ b/web-v4/src/lib/components/HistoryTable.svelte
@@ -11,10 +11,11 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import { formatCurrency } from '$lib/utils/number';
 	import { calculateDeltaMileage, sortNewestDateFirst } from '$lib/utils/records';
-	import { Eye, EyeClosed } from 'lucide-svelte';
+	import { Eye, EyeClosed, ChevronDown, ChevronRight, Paperclip } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import Button from './common/Button.svelte';
 	import { pluralize } from '$lib/utils/text';
+	import AttachmentList from './attachments/AttachmentList.svelte';
 
 	interface Props {
 		history: HistoryEntry[];
@@ -24,6 +25,15 @@
 	let { history, vehicle }: Props = $props();
 
 	let showMileageAdjustments = $state(vehicle.preferences.showMileageAdjustmentRecords);
+
+	let expandedIds = $state<Set<number>>(new Set());
+
+	function toggleExpanded(id: number) {
+		const next = new Set(expandedIds);
+		if (next.has(id)) next.delete(id);
+		else next.add(id);
+		expandedIds = next;
+	}
 
 	const historyNewestFirst = $derived(
 		history
@@ -125,6 +135,8 @@
 
 			{#each groupedRecords[Number(year)] as record (record.id)}
 				{@const deltaMileage = calculateDeltaMileage(record, historyNewestFirst)}
+				{@const isExpanded = expandedIds.has(record.id)}
+				{@const hasAttachments = record.attachments.length > 0}
 
 				<Row class="text-md even:bg-gray-100 dark:even:bg-surface max-sm:gap-1">
 					<Cell class="whitespace-nowrap max-sm:text-sm max-sm:font-bold">
@@ -148,7 +160,25 @@
 					<Cell class="w-full max-sm:py-1">
 						<Markdown src={record.notes} />
 					</Cell>
-					<Cell class="ml-auto">
+					<Cell class="ml-auto flex items-center gap-2">
+						{#if hasAttachments}
+							<Button
+								size="xs"
+								variant="ghost"
+								color="neutral"
+								onclick={() => toggleExpanded(record.id)}
+								aria-label={isExpanded ? 'Hide attachments' : 'Show attachments'}
+								aria-expanded={isExpanded}
+							>
+								<Paperclip size={14} />
+								<span>{record.attachments.length}</span>
+								{#if isExpanded}
+									<ChevronDown size={12} />
+								{:else}
+									<ChevronRight size={12} />
+								{/if}
+							</Button>
+						{/if}
 						<a
 							class="text-sm underline text-brand-500 hover:text-brand-600"
 							href={`/vehicles/${vehicle.id}/history/${record.id}/edit`}
@@ -157,6 +187,14 @@
 						</a>
 					</Cell>
 				</Row>
+
+				{#if isExpanded}
+					<Row class="bg-surface border-t border-ink-200">
+						<Cell class="w-full p-3">
+							<AttachmentList attachments={record.attachments} />
+						</Cell>
+					</Row>
+				{/if}
 			{/each}
 		</FlexTable>
 	</div>

--- a/web-v4/src/lib/components/HistoryTable.svelte
+++ b/web-v4/src/lib/components/HistoryTable.svelte
@@ -189,11 +189,9 @@
 				</Row>
 
 				{#if isExpanded}
-					<Row class="bg-surface border-t border-ink-200">
-						<Cell class="w-full p-3">
-							<AttachmentList attachments={record.attachments} />
-						</Cell>
-					</Row>
+					<div class="bg-surface border-t border-ink-200 px-4 py-3">
+						<AttachmentList attachments={record.attachments} />
+					</div>
 				{/if}
 			{/each}
 		</FlexTable>

--- a/web-v4/src/lib/components/HistoryTable.svelte
+++ b/web-v4/src/lib/components/HistoryTable.svelte
@@ -11,7 +11,7 @@
 	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import { formatCurrency } from '$lib/utils/number';
 	import { calculateDeltaMileage, sortNewestDateFirst } from '$lib/utils/records';
-	import { Eye, EyeClosed, ChevronDown, ChevronRight, Paperclip } from 'lucide-svelte';
+	import { Eye, EyeClosed } from 'lucide-svelte';
 	import { onMount } from 'svelte';
 	import Button from './common/Button.svelte';
 	import { pluralize } from '$lib/utils/text';
@@ -25,15 +25,6 @@
 	let { history, vehicle }: Props = $props();
 
 	let showMileageAdjustments = $state(vehicle.preferences.showMileageAdjustmentRecords);
-
-	let expandedIds = $state<Set<number>>(new Set());
-
-	function toggleExpanded(id: number) {
-		const next = new Set(expandedIds);
-		if (next.has(id)) next.delete(id);
-		else next.add(id);
-		expandedIds = next;
-	}
 
 	const historyNewestFirst = $derived(
 		history
@@ -135,8 +126,6 @@
 
 			{#each groupedRecords[Number(year)] as record (record.id)}
 				{@const deltaMileage = calculateDeltaMileage(record, historyNewestFirst)}
-				{@const isExpanded = expandedIds.has(record.id)}
-				{@const hasAttachments = record.attachments.length > 0}
 
 				<Row class="text-md even:bg-gray-100 dark:even:bg-surface max-sm:gap-1">
 					<Cell class="whitespace-nowrap max-sm:text-sm max-sm:font-bold">
@@ -159,26 +148,13 @@
 					{/if}
 					<Cell class="w-full max-sm:py-1">
 						<Markdown src={record.notes} />
-					</Cell>
-					<Cell class="ml-auto flex items-center gap-2">
-						{#if hasAttachments}
-							<Button
-								size="xs"
-								variant="ghost"
-								color="neutral"
-								onclick={() => toggleExpanded(record.id)}
-								aria-label={isExpanded ? 'Hide attachments' : 'Show attachments'}
-								aria-expanded={isExpanded}
-							>
-								<Paperclip size={14} />
-								<span>{record.attachments.length}</span>
-								{#if isExpanded}
-									<ChevronDown size={12} />
-								{:else}
-									<ChevronRight size={12} />
-								{/if}
-							</Button>
+						{#if record.attachments.length > 0}
+							<div class="mt-2">
+								<AttachmentList attachments={record.attachments} />
+							</div>
 						{/if}
+					</Cell>
+					<Cell class="ml-auto">
 						<a
 							class="text-sm underline text-brand-500 hover:text-brand-600"
 							href={`/vehicles/${vehicle.id}/history/${record.id}/edit`}
@@ -187,12 +163,6 @@
 						</a>
 					</Cell>
 				</Row>
-
-				{#if isExpanded}
-					<div class="bg-surface border-t border-ink-200 px-4 py-3">
-						<AttachmentList attachments={record.attachments} />
-					</div>
-				{/if}
 			{/each}
 		</FlexTable>
 	</div>

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	import { Paperclip, Trash2, RotateCcw } from 'lucide-svelte';
+	import Button from '$lib/components/common/Button.svelte';
+	import type { Attachment } from '$lib/data/attachments';
+	import { ATTACHMENT_SIZE_LIMIT } from '$lib/data/attachments';
+	import { formatBytes } from '$lib/utils/bytes';
+
+	interface Props {
+		existing: Attachment[];
+		markedForDeletion: string[];
+		onMarkDelete: (id: string) => void;
+		onRestore: (id: string) => void;
+	}
+
+	let { existing, markedForDeletion, onMarkDelete, onRestore }: Props = $props();
+
+	let fileError = $state<string | null>(null);
+	let files: FileList | undefined = $state();
+	let inputEl: HTMLInputElement | undefined = $state();
+
+	function handleChange(event: Event) {
+		const input = event.target as HTMLInputElement;
+		const list = input.files;
+		if (!list) return;
+		for (const file of Array.from(list)) {
+			if (file.size > ATTACHMENT_SIZE_LIMIT) {
+				fileError = `"${file.name}" exceeds 10MB limit`;
+				input.value = '';
+				files = undefined;
+				return;
+			}
+		}
+		fileError = null;
+	}
+
+	let selectedFiles = $derived(files ? Array.from(files) : []);
+</script>
+
+<div class="flex flex-col gap-4">
+	{#if existing.length > 0}
+		<div>
+			<h4 class="text-sm font-medium mb-2">Current attachments</h4>
+			<ul class="flex flex-col gap-1 text-sm">
+				{#each existing as att (att.id)}
+					{@const marked = markedForDeletion.includes(att.id)}
+					<li class="flex items-center gap-2">
+						<Paperclip size={14} class="text-ink-400 shrink-0" />
+						<span
+							class="truncate flex-1 min-w-0 {marked ? 'line-through text-ink-400' : ''}"
+							title={att.filename}
+						>
+							{att.filename}
+						</span>
+						<span class="text-ink-400 text-xs whitespace-nowrap">
+							{formatBytes(att.byteSize)}
+						</span>
+						{#if marked}
+							<Button
+								size="xs"
+								variant="ghost"
+								color="neutral"
+								onclick={() => onRestore(att.id)}
+								aria-label="Restore {att.filename}"
+							>
+								<RotateCcw size={14} />
+								Restore
+							</Button>
+						{:else}
+							<Button
+								size="xs"
+								variant="ghost"
+								color="neutral"
+								onclick={() => onMarkDelete(att.id)}
+								aria-label="Remove {att.filename}"
+							>
+								<Trash2 size={14} />
+							</Button>
+						{/if}
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+
+	{#if selectedFiles.length > 0}
+		<div>
+			<h4 class="text-sm font-medium mb-2">New files to upload</h4>
+			<ul class="flex flex-col gap-1 text-sm">
+				{#each selectedFiles as file (file.name + file.size)}
+					<li class="flex items-center gap-2">
+						<Paperclip size={14} class="text-ink-400 shrink-0" />
+						<span class="truncate flex-1 min-w-0" title={file.name}>{file.name}</span>
+						<span class="text-ink-400 text-xs whitespace-nowrap">{formatBytes(file.size)}</span>
+					</li>
+				{/each}
+			</ul>
+			<p class="text-xs text-ink-400 mt-1">Re-pick via "Add files" to change selection.</p>
+		</div>
+	{/if}
+
+	<div>
+		<label class="inline-flex items-center gap-2 cursor-pointer">
+			<Button variant="outline" as="span">
+				<Paperclip size={16} />
+				Add files
+			</Button>
+			<input
+				bind:this={inputEl}
+				bind:files
+				type="file"
+				multiple
+				name="record[attachments][]"
+				class="hidden"
+				onchange={handleChange}
+			/>
+		</label>
+		{#if fileError}
+			<p class="text-sm text-negative mt-1">{fileError}</p>
+		{/if}
+		<p class="text-xs text-ink-400 mt-1">Max 10MB per file</p>
+	</div>
+</div>

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -16,7 +16,7 @@
 	let { existing, markedForDeletion, onMarkDelete, onRestore }: Props = $props();
 
 	let fileError = $state<string | null>(null);
-	let files: FileList | undefined = $state();
+	let files: FileList | null = $state(null);
 
 	function handleFileInput(input: HTMLInputElement) {
 		const list = input.files;
@@ -25,14 +25,14 @@
 			if (file.size > ATTACHMENT_SIZE_LIMIT) {
 				fileError = `"${file.name}" exceeds 10MB limit`;
 				input.value = '';
-				files = undefined;
+				files = null;
 				return;
 			}
 		}
 		fileError = null;
 	}
 
-	let selectedFiles = $derived(files ? Array.from(files) : []);
+	let selectedFiles: File[] = $derived(files ? Array.from(files) : []);
 </script>
 
 <div class="flex flex-col gap-4">
@@ -99,6 +99,7 @@
 
 	<div>
 		<FileInput
+			bind:files
 			name="record[attachments][]"
 			multiple
 			buttonLabel="Add files"

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -2,6 +2,7 @@
 	import { Paperclip, Trash2, RotateCcw } from 'lucide-svelte';
 	import Button from '$lib/components/common/Button.svelte';
 	import FileInput from '$lib/components/forms/FileInput.svelte';
+	import Tooltip from '$lib/components/common/Tooltip.svelte';
 	import type { Attachment } from '$lib/data/attachments';
 	import { ATTACHMENT_SIZE_LIMIT } from '$lib/data/attachments';
 	import { formatBytes } from '$lib/utils/bytes';
@@ -11,95 +12,135 @@
 		markedForDeletion: string[];
 		onMarkDelete: (id: string) => void;
 		onRestore: (id: string) => void;
+		/** New files staged for upload. Parent binds and submits. */
+		selectedFiles?: File[];
+		onSelectedFilesChange?: (files: File[]) => void;
 	}
 
-	let { existing, markedForDeletion, onMarkDelete, onRestore }: Props = $props();
+	let {
+		existing,
+		markedForDeletion,
+		onMarkDelete,
+		onRestore,
+		selectedFiles = $bindable([]),
+		onSelectedFilesChange,
+	}: Props = $props();
 
 	let fileError = $state<string | null>(null);
-	let files: FileList | null = $state(null);
+
+	function fileKey(file: File): string {
+		return `${file.name}_${file.size}_${file.lastModified}`;
+	}
 
 	function handleFileInput(input: HTMLInputElement) {
 		const list = input.files;
 		if (!list) return;
+		const existingKeys = new Set(selectedFiles.map(fileKey));
+		const additions: File[] = [];
 		for (const file of Array.from(list)) {
 			if (file.size > ATTACHMENT_SIZE_LIMIT) {
 				fileError = `"${file.name}" exceeds 10MB limit`;
 				input.value = '';
-				files = null;
 				return;
 			}
+			const key = fileKey(file);
+			if (existingKeys.has(key)) continue;
+			existingKeys.add(key);
+			additions.push(file);
+		}
+		if (additions.length === 0) {
+			input.value = '';
+			return;
 		}
 		fileError = null;
+		const next = [...selectedFiles, ...additions];
+		selectedFiles = next;
+		onSelectedFilesChange?.(next);
+		input.value = '';
 	}
 
-	let selectedFiles: File[] = $derived(files ? Array.from(files) : []);
+	function removeNewFile(index: number) {
+		const next = selectedFiles.filter((_, i) => i !== index);
+		selectedFiles = next;
+		onSelectedFilesChange?.(next);
+	}
 </script>
 
-<div class="flex flex-col gap-4">
+<div class="flex flex-col gap-2">
 	{#if existing.length > 0}
-		<div>
-			<h4 class="text-sm font-medium mb-2">Current attachments</h4>
-			<ul class="flex flex-col gap-1 text-sm">
-				{#each existing as att (att.id)}
-					{@const marked = markedForDeletion.includes(att.id)}
-					<li class="flex items-center gap-2">
-						<Paperclip size={14} class="text-ink-400 shrink-0" />
+		<ul class="flex flex-col gap-2 text-sm">
+			{#each existing as att (att.id)}
+				{@const marked = markedForDeletion.includes(att.id)}
+				<li class="flex items-center gap-2">
+					<Paperclip size={14} class="text-ink-400 shrink-0" />
+					<span class="flex-1 min-w-0">
 						<span
-							class="truncate flex-1 min-w-0 {marked ? 'line-through text-ink-400' : ''}"
+							class="block truncate font-medium {marked ? 'line-through text-ink-400' : ''}"
 							title={att.filename}
 						>
 							{att.filename}
 						</span>
-						<span class="text-ink-400 text-xs whitespace-nowrap">
-							{formatBytes(att.byteSize)}
-						</span>
-						{#if marked}
-							<Button
-								size="xs"
-								variant="ghost"
-								color="neutral"
-								onclick={() => onRestore(att.id)}
-								aria-label="Restore {att.filename}"
-							>
-								<RotateCcw size={14} />
-								Restore
-							</Button>
-						{:else}
-							<Button
-								size="xs"
-								variant="ghost"
-								color="neutral"
-								onclick={() => onMarkDelete(att.id)}
-								aria-label="Remove {att.filename}"
-							>
-								<Trash2 size={14} />
-							</Button>
-						{/if}
-					</li>
-				{/each}
-			</ul>
-		</div>
+						<span class="block text-xs text-ink-400">{formatBytes(att.byteSize)}</span>
+					</span>
+					{#if marked}
+						<Tooltip content={`Restore ${att.filename}`}>
+							{#snippet children(triggerProps)}
+								<Button
+									size="sm"
+									variant="ghost"
+									color="neutral"
+									icon
+									{...triggerProps}
+									onclick={() => onRestore(att.id)}
+									aria-label="Restore {att.filename}"
+								>
+									<RotateCcw size={14} />
+								</Button>
+							{/snippet}
+						</Tooltip>
+					{:else}
+						<Button
+							size="sm"
+							variant="ghost"
+							color="neutral"
+							icon
+							onclick={() => onMarkDelete(att.id)}
+							aria-label="Remove {att.filename}"
+						>
+							<Trash2 size={14} />
+						</Button>
+					{/if}
+				</li>
+			{/each}
+		</ul>
 	{/if}
 
 	{#if selectedFiles.length > 0}
-		<div>
-			<h4 class="text-sm font-medium mb-2">New files to upload</h4>
-			<ul class="flex flex-col gap-1 text-sm">
-				{#each selectedFiles as file, i (file.name + '_' + file.lastModified + '_' + i)}
-					<li class="flex items-center gap-2">
-						<Paperclip size={14} class="text-ink-400 shrink-0" />
-						<span class="truncate flex-1 min-w-0" title={file.name}>{file.name}</span>
-						<span class="text-ink-400 text-xs whitespace-nowrap">{formatBytes(file.size)}</span>
-					</li>
-				{/each}
-			</ul>
-			<p class="text-xs text-ink-400 mt-1">Re-pick via "Add files" to change selection.</p>
-		</div>
+		<ul class="flex flex-col gap-2 text-sm">
+			{#each selectedFiles as file, i (fileKey(file))}
+				<li class="flex items-center gap-2">
+					<Paperclip size={14} class="text-ink-400 shrink-0" />
+					<span class="flex-1 min-w-0">
+						<span class="block truncate font-medium" title={file.name}>{file.name}</span>
+						<span class="block text-xs text-ink-400">{formatBytes(file.size)}</span>
+					</span>
+					<Button
+						size="sm"
+						variant="ghost"
+						color="neutral"
+						icon
+						onclick={() => removeNewFile(i)}
+						aria-label="Remove {file.name}"
+					>
+						<Trash2 size={14} />
+					</Button>
+				</li>
+			{/each}
+		</ul>
 	{/if}
 
 	<div>
 		<FileInput
-			bind:files
 			name="record[attachments][]"
 			multiple
 			buttonLabel="Add files"

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -16,6 +16,7 @@
 
 	let fileError = $state<string | null>(null);
 	let files: FileList | undefined = $state();
+	let inputEl: HTMLInputElement | undefined = $state();
 
 	function handleChange(event: Event) {
 		const input = event.target as HTMLInputElement;
@@ -98,20 +99,19 @@
 	{/if}
 
 	<div>
-		<label class="inline-flex items-center gap-2 cursor-pointer">
-			<Button variant="outline">
-				<Paperclip size={16} />
-				Add files
-			</Button>
-			<input
-				bind:files
-				type="file"
-				multiple
-				name="record[attachments][]"
-				class="hidden"
-				onchange={handleChange}
-			/>
-		</label>
+		<Button variant="outline" size="sm" onclick={() => inputEl?.click()}>
+			<Paperclip size={16} />
+			Add files
+		</Button>
+		<input
+			bind:this={inputEl}
+			bind:files
+			type="file"
+			multiple
+			name="record[attachments][]"
+			class="hidden"
+			onchange={handleChange}
+		/>
 		{#if fileError}
 			<p class="text-sm text-negative mt-1">{fileError}</p>
 		{/if}

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -16,7 +16,6 @@
 
 	let fileError = $state<string | null>(null);
 	let files: FileList | undefined = $state();
-	let inputEl: HTMLInputElement | undefined = $state();
 
 	function handleChange(event: Event) {
 		const input = event.target as HTMLInputElement;
@@ -86,7 +85,7 @@
 		<div>
 			<h4 class="text-sm font-medium mb-2">New files to upload</h4>
 			<ul class="flex flex-col gap-1 text-sm">
-				{#each selectedFiles as file (file.name + file.size)}
+				{#each selectedFiles as file, i (file.name + '_' + file.lastModified + '_' + i)}
 					<li class="flex items-center gap-2">
 						<Paperclip size={14} class="text-ink-400 shrink-0" />
 						<span class="truncate flex-1 min-w-0" title={file.name}>{file.name}</span>
@@ -100,12 +99,11 @@
 
 	<div>
 		<label class="inline-flex items-center gap-2 cursor-pointer">
-			<Button variant="outline" as="span">
+			<Button variant="outline">
 				<Paperclip size={16} />
 				Add files
 			</Button>
 			<input
-				bind:this={inputEl}
 				bind:files
 				type="file"
 				multiple

--- a/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentEditor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { Paperclip, Trash2, RotateCcw } from 'lucide-svelte';
 	import Button from '$lib/components/common/Button.svelte';
+	import FileInput from '$lib/components/forms/FileInput.svelte';
 	import type { Attachment } from '$lib/data/attachments';
 	import { ATTACHMENT_SIZE_LIMIT } from '$lib/data/attachments';
 	import { formatBytes } from '$lib/utils/bytes';
@@ -16,10 +17,8 @@
 
 	let fileError = $state<string | null>(null);
 	let files: FileList | undefined = $state();
-	let inputEl: HTMLInputElement | undefined = $state();
 
-	function handleChange(event: Event) {
-		const input = event.target as HTMLInputElement;
+	function handleFileInput(input: HTMLInputElement) {
 		const list = input.files;
 		if (!list) return;
 		for (const file of Array.from(list)) {
@@ -99,18 +98,11 @@
 	{/if}
 
 	<div>
-		<Button variant="outline" size="sm" onclick={() => inputEl?.click()}>
-			<Paperclip size={16} />
-			Add files
-		</Button>
-		<input
-			bind:this={inputEl}
-			bind:files
-			type="file"
-			multiple
+		<FileInput
 			name="record[attachments][]"
-			class="hidden"
-			onchange={handleChange}
+			multiple
+			buttonLabel="Add files"
+			onChange={handleFileInput}
 		/>
 		{#if fileError}
 			<p class="text-sm text-negative mt-1">{fileError}</p>

--- a/web-v4/src/lib/components/attachments/AttachmentList.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentList.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import { Paperclip } from 'lucide-svelte';
+	import type { Attachment } from '$lib/data/attachments';
+	import { formatBytes } from '$lib/utils/bytes';
+
+	interface Props {
+		attachments: Attachment[];
+	}
+
+	let { attachments }: Props = $props();
+</script>
+
+{#if attachments.length > 0}
+	<ul class="flex flex-col gap-1 text-sm">
+		{#each attachments as att (att.id)}
+			<li class="flex items-center gap-2">
+				<Paperclip size={14} class="text-ink-400 shrink-0" />
+				<a
+					href={att.url}
+					download={att.filename}
+					class="text-brand-500 hover:text-brand-600 hover:underline truncate flex-1 min-w-0"
+					title={att.filename}
+				>
+					{att.filename}
+				</a>
+				<span class="text-ink-400 text-xs whitespace-nowrap">{formatBytes(att.byteSize)}</span>
+			</li>
+		{/each}
+	</ul>
+{/if}

--- a/web-v4/src/lib/components/attachments/AttachmentList.svelte
+++ b/web-v4/src/lib/components/attachments/AttachmentList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Paperclip } from 'lucide-svelte';
 	import type { Attachment } from '$lib/data/attachments';
-	import { formatBytes } from '$lib/utils/bytes';
 
 	interface Props {
 		attachments: Attachment[];
@@ -18,12 +17,13 @@
 				<a
 					href={att.url}
 					download={att.filename}
+					target="_blank"
+					rel="noopener noreferrer"
 					class="text-brand-500 hover:text-brand-600 hover:underline truncate flex-1 min-w-0"
 					title={att.filename}
 				>
 					{att.filename}
 				</a>
-				<span class="text-ink-400 text-xs whitespace-nowrap">{formatBytes(att.byteSize)}</span>
 			</li>
 		{/each}
 	</ul>

--- a/web-v4/src/lib/components/forms/FileInput.svelte
+++ b/web-v4/src/lib/components/forms/FileInput.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Upload } from 'lucide-svelte';
+	import { Paperclip } from 'lucide-svelte';
 	import Button from '$lib/components/common/Button.svelte';
 	import type { ButtonVariant, ButtonSize } from '$lib/components/common/Button.svelte';
 	import type { ClassValue } from 'svelte/elements';
@@ -56,7 +56,7 @@
 		type="button"
 		onclick={() => inputEl?.click()}
 	>
-		<Upload size={16} />
+		<Paperclip size={16} />
 		{label}
 	</Button>
 	<input

--- a/web-v4/src/lib/components/forms/FileInput.svelte
+++ b/web-v4/src/lib/components/forms/FileInput.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import { Upload } from 'lucide-svelte';
+	import Button from '$lib/components/common/Button.svelte';
+	import type { ButtonVariant, ButtonSize } from '$lib/components/common/Button.svelte';
+	import type { ClassValue } from 'svelte/elements';
+
+	interface Props {
+		/** Form field name (e.g. "record[attachments][]", "file"). Required. */
+		name: string;
+		/** Optional accept attribute (e.g. ".csv", "image/*"). */
+		accept?: string;
+		/** Allow multiple file selection. */
+		multiple?: boolean;
+		/** Controlled FileList. Bind with `bind:files` on the call site. */
+		files?: FileList | null;
+		/** Change handler — receives the input element so caller can read .files / reset .value. */
+		onChange?: (input: HTMLInputElement) => void;
+		/** Button label. Default: "Choose file" (or "Choose files" when multiple). */
+		buttonLabel?: string;
+		/** Button variant. Default: "outline". */
+		buttonVariant?: ButtonVariant;
+		/** Button size. Default: "sm". */
+		buttonSize?: ButtonSize;
+		/** Extra classes for the wrapping div. */
+		class?: ClassValue;
+	}
+
+	let {
+		name,
+		accept,
+		multiple = false,
+		files = $bindable(null),
+		onChange,
+		buttonLabel,
+		buttonVariant = 'outline',
+		buttonSize = 'sm',
+		class: className,
+	}: Props = $props();
+
+	let inputEl: HTMLInputElement | undefined = $state();
+
+	let label = $derived(
+		buttonLabel ?? (multiple ? 'Choose files' : 'Choose file')
+	);
+
+	function handleChange(event: Event) {
+		const input = event.target as HTMLInputElement;
+		onChange?.(input);
+	}
+</script>
+
+<div class={['inline-flex', className]}>
+	<Button
+		variant={buttonVariant}
+		size={buttonSize}
+		type="button"
+		onclick={() => inputEl?.click()}
+	>
+		<Upload size={16} />
+		{label}
+	</Button>
+	<input
+		bind:this={inputEl}
+		bind:files
+		type="file"
+		{name}
+		{accept}
+		{multiple}
+		class="hidden"
+		onchange={handleChange}
+	/>
+</div>

--- a/web-v4/src/lib/components/forms/RecordForm.svelte
+++ b/web-v4/src/lib/components/forms/RecordForm.svelte
@@ -25,7 +25,7 @@
 	let attachmentErrors = $derived(errors.filter((e) => e.id === 'attachments'));
 
 	let date = $state(
-		record?.date ? formatDateISO(new Date(record.date)) : formatDateISO(new Date())
+		record?.date ? formatDateISO(new Date(record.date)) : formatDateISO(new Date()),
 	);
 	let mileage = $state(record?.mileage?.toString() ?? '');
 	let notes = $state(record?.notes ?? '');
@@ -60,36 +60,26 @@
 	{/if}
 
 	<fieldset class="flex flex-col gap-4">
-		<div class="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-4 md:gap-7">
-			<div>
-				<Field name="date" label="Date" {errors} required>
-					<Input type="date" name="date" bind:value={date} required />
-				</Field>
-			</div>
-			<div class="space-y-4">
-				<Field name="notes" label="Notes" {errors} required>
-					<Textarea name="notes" bind:value={notes} required class="min-h-[100px]" />
-				</Field>
+		<Field name="date" label="Date" {errors} required>
+			<Input type="date" name="date" bind:value={date} required />
+		</Field>
+		<Field name="notes" label="Notes" {errors} required>
+			<Textarea name="notes" bind:value={notes} required class="min-h-[100px]" />
+		</Field>
 
-				<Field
-					name="mileage"
-					label={vehicle.distanceUnit === 'mi' ? 'Mileage' : 'Distance'}
-					{errors}
-				>
-					<InputGroup name="mileage" bind:value={mileage} inputmode="numeric">
-						{#snippet endAddon()}{vehicle.distanceUnit}{/snippet}
-					</InputGroup>
-				</Field>
+		<Field name="mileage" label={vehicle.distanceUnit === 'mi' ? 'Mileage' : 'Distance'} {errors}>
+			<InputGroup name="mileage" bind:value={mileage} inputmode="numeric">
+				{#snippet endAddon()}{vehicle.distanceUnit}{/snippet}
+			</InputGroup>
+		</Field>
 
-				{#if vehicle.preferences.enableCost}
-					<Field name="cost" label="Cost" {errors}>
-						<InputGroup name="cost" bind:value={cost} inputmode="numeric">
-							{#snippet startAddon()}{getCurrencySymbol()}{/snippet}
-						</InputGroup>
-					</Field>
-				{/if}
-			</div>
-		</div>
+		{#if vehicle.preferences.enableCost}
+			<Field name="cost" label="Cost" {errors}>
+				<InputGroup name="cost" bind:value={cost} inputmode="numeric">
+					{#snippet startAddon()}{getCurrencySymbol()}{/snippet}
+				</InputGroup>
+			</Field>
+		{/if}
 	</fieldset>
 
 	<Field name="attachments" label="Attachments" errors={attachmentErrors}>

--- a/web-v4/src/lib/components/forms/RecordForm.svelte
+++ b/web-v4/src/lib/components/forms/RecordForm.svelte
@@ -5,6 +5,7 @@
 	import Input from '$lib/components/common/Input.svelte';
 	import InputGroup from '$lib/components/common/InputGroup.svelte';
 	import Textarea from '$lib/components/common/Textarea.svelte';
+	import AttachmentEditor from '$lib/components/attachments/AttachmentEditor.svelte';
 	import { formatDateISO } from '$lib/utils/date';
 	import { getCurrencySymbol } from '$lib/utils/number';
 	import type { HistoryEntry } from '$lib/data/history';
@@ -21,18 +22,32 @@
 	let { vehicle, record, errors = [], action }: Props = $props();
 
 	let formErrors = $derived(errors.filter((e) => e.id === 'form'));
+	let attachmentErrors = $derived(errors.filter((e) => e.id === 'attachments'));
 
 	let date = $state(
-		record?.date ? formatDateISO(new Date(record.date)) : formatDateISO(new Date()),
+		record?.date ? formatDateISO(new Date(record.date)) : formatDateISO(new Date())
 	);
 	let mileage = $state(record?.mileage?.toString() ?? '');
 	let notes = $state(record?.notes ?? '');
 	let cost = $state(record?.cost ?? '');
+
+	let markedForDeletion = $state<string[]>([]);
+
+	function handleMarkDelete(id: string) {
+		if (!markedForDeletion.includes(id)) {
+			markedForDeletion = [...markedForDeletion, id];
+		}
+	}
+
+	function handleRestore(id: string) {
+		markedForDeletion = markedForDeletion.filter((x) => x !== id);
+	}
 </script>
 
 <form
 	method="POST"
 	action={action ?? `/vehicles/${vehicle.id}/records${record?.id ? `/${record.id}` : ''}`}
+	enctype="multipart/form-data"
 	use:enhance
 	class="flex flex-col gap-6"
 >
@@ -76,6 +91,17 @@
 			</div>
 		</div>
 	</fieldset>
+
+	<Field name="attachments" label="Attachments" errors={attachmentErrors}>
+		<AttachmentEditor
+			existing={record?.attachments ?? []}
+			{markedForDeletion}
+			onMarkDelete={handleMarkDelete}
+			onRestore={handleRestore}
+		/>
+	</Field>
+
+	<input type="hidden" name="attachments_to_delete" value={markedForDeletion.join(',')} />
 
 	<div class="flex gap-3">
 		<Button type="submit">

--- a/web-v4/src/lib/components/forms/RecordForm.svelte
+++ b/web-v4/src/lib/components/forms/RecordForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { enhance } from '$app/forms';
+	import type { SubmitFunction } from '@sveltejs/kit';
 	import Button from '$lib/components/common/Button.svelte';
 	import Field from '$lib/components/common/Field.svelte';
 	import Input from '$lib/components/common/Input.svelte';
@@ -19,7 +20,9 @@
 		action?: string;
 	}
 
-	let { vehicle, record, errors = [], action }: Props = $props();
+	let { vehicle, record, errors = [], action = '' }: Props = $props();
+
+	let recordId = record?.id;
 
 	let formErrors = $derived(errors.filter((e) => e.id === 'form'));
 	let attachmentErrors = $derived(errors.filter((e) => e.id === 'attachments'));
@@ -32,6 +35,7 @@
 	let cost = $state(record?.cost ?? '');
 
 	let markedForDeletion = $state<string[]>([]);
+	let selectedFiles = $state<File[]>([]);
 
 	function handleMarkDelete(id: string) {
 		if (!markedForDeletion.includes(id)) {
@@ -42,13 +46,53 @@
 	function handleRestore(id: string) {
 		markedForDeletion = markedForDeletion.filter((x) => x !== id);
 	}
+
+	let formAction = $derived(action);
+
+	// Custom submit: rebuild FormData with the staged files because the
+	// browser's FileList can't be edited (no per-file removal API).
+	const submit: SubmitFunction = ({ formData, cancel }) => {
+		const fd = new FormData();
+		for (const [key, value] of formData.entries()) {
+			if (key.startsWith('record[attachments]')) continue;
+			fd.append(key, value);
+		}
+		for (const file of selectedFiles) {
+			fd.append('record[attachments][]', file);
+		}
+		cancel();
+		fetch(formAction, {
+			method: 'POST',
+			body: fd,
+			headers: { Accept: 'application/json' },
+		})
+			.then(async (response) => {
+				if (response.redirected) {
+					window.location.href = response.url;
+					return;
+				}
+				if (response.ok) {
+					window.location.href = `/vehicles/${vehicle.id}`;
+					return;
+				}
+				// Re-render the page with returned errors so the user sees them.
+				const html = await response.text();
+				document.open();
+				document.write(html);
+				document.close();
+			})
+			.catch(() => {
+				// Network error — leave the user on the form to retry.
+			});
+		return () => {};
+	};
 </script>
 
 <form
 	method="POST"
-	action={action ?? `/vehicles/${vehicle.id}/records${record?.id ? `/${record.id}` : ''}`}
+	action={formAction}
 	enctype="multipart/form-data"
-	use:enhance
+	use:enhance={submit}
 	class="flex flex-col gap-6"
 >
 	{#if formErrors.length > 0}
@@ -86,6 +130,7 @@
 		<AttachmentEditor
 			existing={record?.attachments ?? []}
 			{markedForDeletion}
+			bind:selectedFiles
 			onMarkDelete={handleMarkDelete}
 			onRestore={handleRestore}
 		/>
@@ -95,7 +140,7 @@
 
 	<div class="flex gap-3">
 		<Button type="submit">
-			{record ? 'Update' : 'Create'} Record
+			{recordId ? 'Update' : 'Create'} Record
 		</Button>
 	</div>
 </form>

--- a/web-v4/src/lib/data/attachments.ts
+++ b/web-v4/src/lib/data/attachments.ts
@@ -1,0 +1,9 @@
+export interface Attachment {
+	id: string;
+	filename: string;
+	contentType: string;
+	byteSize: number;
+	url: string;
+}
+
+export const ATTACHMENT_SIZE_LIMIT = 10 * 1024 * 1024;

--- a/web-v4/src/lib/data/history.ts
+++ b/web-v4/src/lib/data/history.ts
@@ -1,4 +1,5 @@
 import { createAPIRequest, type RequestOpts } from './client';
+import type { Attachment } from './attachments';
 
 export type HistoryEntryType = 'mileage adjustment';
 
@@ -12,6 +13,7 @@ export interface HistoryEntry {
 	createdAt: string;
 	updatedAt: string;
 	recordType: HistoryEntryType | null;
+	attachments: Attachment[];
 }
 
 const request = createAPIRequest();

--- a/web-v4/src/lib/data/multipart.test.ts
+++ b/web-v4/src/lib/data/multipart.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('$env/static/private', () => ({
+	PROXY_HOST: 'http://api.test'
+}));
+
+import { uploadRecord, deleteAttachment } from './multipart';
+
+describe('uploadRecord', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn());
+	});
+
+	it('POSTs FormData on create', async () => {
+		const fetchMock = vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ id: 1 }), { status: 201 })
+		);
+		const form = new FormData();
+		form.append('date', '2024-01-15');
+		const file = new File(['content'], 'test.pdf', { type: 'application/pdf' });
+		form.append('record[attachments][]', file);
+
+		await uploadRecord(42, undefined, form, { authToken: 'tok-123' });
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://api.test/vehicles/42/records');
+		expect(init?.method).toBe('POST');
+		expect(init?.body).toBe(form);
+		expect((init?.headers as Headers).get('Authorization')).toBe('Token tok-123');
+	});
+
+	it('PUTs FormData on edit', async () => {
+		const fetchMock = vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ id: 1 }), { status: 200 })
+		);
+		const form = new FormData();
+
+		await uploadRecord(42, 7, form, { authToken: 'tok-123' });
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://api.test/vehicles/42/records/7');
+		expect(init?.method).toBe('PUT');
+	});
+
+	it('throws on backend error with parsed body', async () => {
+		vi.mocked(fetch).mockResolvedValue(
+			new Response(JSON.stringify({ error: 'too large' }), { status: 422 })
+		);
+		const form = new FormData();
+
+		await expect(
+			uploadRecord(42, undefined, form, { authToken: 'tok' })
+		).rejects.toThrow('HTTP Error: 422');
+	});
+});
+
+describe('deleteAttachment', () => {
+	beforeEach(() => {
+		vi.stubGlobal('fetch', vi.fn());
+	});
+
+	it('sends DELETE with auth header', async () => {
+		const fetchMock = vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 204 }));
+		await deleteAttachment(42, 7, 'signed-id-abc', { authToken: 'tok' });
+
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(url).toBe('http://api.test/vehicles/42/records/7/attachments/signed-id-abc');
+		expect(init?.method).toBe('DELETE');
+		expect((init?.headers as Headers).get('Authorization')).toBe('Token tok');
+	});
+});

--- a/web-v4/src/lib/data/multipart.ts
+++ b/web-v4/src/lib/data/multipart.ts
@@ -5,22 +5,21 @@ import { HTTPError } from './client';
 const ACCEPT_HEADER = 'application/vnd.api+json; version=2';
 
 /**
- * Wrap flat form fields under `record[...]` so the Rails backend's strong
- * params (`params.require(:record).permit(...)`) see them nested.
- * Entries already starting with `record[` are passed through unchanged.
- * Entries in `skip` are dropped (e.g. `attachments_to_delete`, which the
- * SvelteKit action handles separately via the DELETE endpoint).
+ * Build a multipart FormData from a flat record object, wrapping each key
+ * under an optional `prefix[...]` so the backend can read it via strong
+ * params (`params.require(:prefix).permit(...)`). Undefined/null values
+ * are skipped.
  */
-export function nestRecordFields(source: FormData, skip: string[] = []): FormData {
-	const skipSet = new Set(skip);
+export function toMultipartFormData(
+	entries: Record<string, unknown>,
+	options: { prefix?: string } = {}
+): FormData {
+	const { prefix } = options;
 	const out = new FormData();
-	for (const [key, value] of source.entries()) {
-		if (skipSet.has(key)) continue;
-		if (key.startsWith('record[')) {
-			out.append(key, value);
-		} else {
-			out.append(`record[${key}]`, value);
-		}
+	for (const [key, value] of Object.entries(entries)) {
+		if (value === undefined || value === null) continue;
+		const name = prefix ? `${prefix}[${key}]` : key;
+		out.append(name, String(value));
 	}
 	return out;
 }

--- a/web-v4/src/lib/data/multipart.ts
+++ b/web-v4/src/lib/data/multipart.ts
@@ -4,6 +4,27 @@ import { HTTPError } from './client';
 
 const ACCEPT_HEADER = 'application/vnd.api+json; version=2';
 
+/**
+ * Wrap flat form fields under `record[...]` so the Rails backend's strong
+ * params (`params.require(:record).permit(...)`) see them nested.
+ * Entries already starting with `record[` are passed through unchanged.
+ * Entries in `skip` are dropped (e.g. `attachments_to_delete`, which the
+ * SvelteKit action handles separately via the DELETE endpoint).
+ */
+export function nestRecordFields(source: FormData, skip: string[] = []): FormData {
+	const skipSet = new Set(skip);
+	const out = new FormData();
+	for (const [key, value] of source.entries()) {
+		if (skipSet.has(key)) continue;
+		if (key.startsWith('record[')) {
+			out.append(key, value);
+		} else {
+			out.append(`record[${key}]`, value);
+		}
+	}
+	return out;
+}
+
 export async function uploadRecord(
 	vehicleId: string | number,
 	recordId: string | number | undefined,

--- a/web-v4/src/lib/data/multipart.ts
+++ b/web-v4/src/lib/data/multipart.ts
@@ -1,0 +1,64 @@
+import { PROXY_HOST } from '$env/static/private';
+import type { RequestOpts } from './client';
+import { HTTPError } from './client';
+
+const ACCEPT_HEADER = 'application/vnd.api+json; version=2';
+
+export async function uploadRecord(
+	vehicleId: string | number,
+	recordId: string | number | undefined,
+	formData: FormData,
+	opts: RequestOpts
+): Promise<unknown> {
+	const path = recordId
+		? `${PROXY_HOST}/vehicles/${vehicleId}/records/${recordId}`
+		: `${PROXY_HOST}/vehicles/${vehicleId}/records`;
+	const headers = new Headers({ Accept: ACCEPT_HEADER });
+	if (opts.authToken) {
+		headers.set('Authorization', `Token ${opts.authToken}`);
+	}
+
+	const response = await fetch(path, {
+		method: recordId ? 'PUT' : 'POST',
+		body: formData,
+		headers
+	});
+
+	const text = await response.text();
+	if (!response.ok) {
+		const data = text ? safeParse(text) : text;
+		throw new HTTPError(response, data);
+	}
+	return text ? safeParse(text) : text;
+}
+
+export async function deleteAttachment(
+	vehicleId: string | number,
+	recordId: string | number,
+	signedId: string,
+	opts: RequestOpts
+): Promise<void> {
+	const headers = new Headers({ Accept: ACCEPT_HEADER });
+	if (opts.authToken) {
+		headers.set('Authorization', `Token ${opts.authToken}`);
+	}
+
+	const response = await fetch(
+		`${PROXY_HOST}/vehicles/${vehicleId}/records/${recordId}/attachments/${signedId}`,
+		{ method: 'DELETE', headers }
+	);
+
+	if (!response.ok) {
+		const text = await response.text();
+		const data = text ? safeParse(text) : text;
+		throw new HTTPError(response, data);
+	}
+}
+
+function safeParse(text: string): unknown {
+	try {
+		return JSON.parse(text);
+	} catch {
+		return text;
+	}
+}

--- a/web-v4/src/lib/utils/bytes.test.ts
+++ b/web-v4/src/lib/utils/bytes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './bytes';
+
+describe('formatBytes', () => {
+	it('formats bytes', () => {
+		expect(formatBytes(500)).toBe('500 B');
+	});
+
+	it('formats kilobytes', () => {
+		expect(formatBytes(2048)).toBe('2.0 KB');
+	});
+
+	it('formats megabytes', () => {
+		expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB');
+	});
+
+	it('formats gigabytes', () => {
+		expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2.00 GB');
+	});
+
+	it('handles zero', () => {
+		expect(formatBytes(0)).toBe('0 B');
+	});
+});

--- a/web-v4/src/lib/utils/bytes.ts
+++ b/web-v4/src/lib/utils/bytes.ts
@@ -1,0 +1,8 @@
+export function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+	const value = bytes / Math.pow(1024, i);
+	const decimals = i === 0 ? 0 : i <= 2 ? 1 : 2;
+	return `${value.toFixed(decimals)} ${units[i]}`;
+}

--- a/web-v4/src/lib/utils/form.test.ts
+++ b/web-v4/src/lib/utils/form.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { decode } from './form';
+
+describe('decode', () => {
+	it('parses flat keys', () => {
+		const fd = new FormData();
+		fd.append('date', '2024-01-15');
+		fd.append('notes', 'oil change');
+
+		const result = decode(fd);
+		expect(result).toEqual({ date: '2024-01-15', notes: 'oil change' });
+	});
+
+	it('parses nested keys with dot notation', () => {
+		const fd = new FormData();
+		fd.append('preferences.enableCost', 'true');
+
+		const result = decode(fd);
+		expect(result).toEqual({ preferences: { enableCost: true } });
+	});
+
+	it('parses nested keys with bracket notation (Rails style)', () => {
+		const fd = new FormData();
+		fd.append('record[date]', '2024-01-15');
+		fd.append('record[notes]', 'oil change');
+
+		const result = decode(fd);
+		expect(result).toEqual({ record: { date: '2024-01-15', notes: 'oil change' } });
+	});
+
+	it('coerces numeric values', () => {
+		const fd = new FormData();
+		fd.append('mileage', '12345');
+
+		const result = decode(fd);
+		expect(result).toEqual({ mileage: 12345 });
+	});
+
+	it('coerces boolean values', () => {
+		const fd = new FormData();
+		fd.append('active', 'on');
+		fd.append('enabled', 'false');
+
+		const result = decode(fd);
+		expect(result).toEqual({ active: true, enabled: false });
+	});
+
+	it('applies schema for boolean defaults', () => {
+		const fd = new FormData();
+		fd.append('name', 'test');
+
+		const result = decode(fd, {
+			name: 'string',
+			'preferences.notify': 'boolean'
+		});
+		expect(result).toEqual({
+			name: 'test',
+			preferences: { notify: false }
+		});
+	});
+});

--- a/web-v4/src/lib/utils/form.ts
+++ b/web-v4/src/lib/utils/form.ts
@@ -24,6 +24,15 @@ export const createInlineEnhance = ({
 
 export const enhanceInline = createInlineEnhance();
 
+/**
+ * Split a FormData key into nesting segments. Accepts both dot notation
+ * (`preferences.enableCost`) and Rails-style bracket notation (`record[date]`).
+ * Empty segments (from a trailing `[...]`) are dropped.
+ */
+function splitKey(key: string): string[] {
+	return key.split(/[.[\]]+/).filter(Boolean);
+}
+
 export function decode(
 	formData: FormData,
 	schema?: Record<string, 'boolean' | 'string' | 'number'>,
@@ -39,7 +48,7 @@ export function decode(
 	const result: Record<string, any> = {};
 
 	for (const [key, value] of formData.entries()) {
-		const keys = key.split('.');
+		const keys = splitKey(key);
 		let current = result;
 
 		for (let i = 0; i < keys.length; i++) {
@@ -56,7 +65,7 @@ export function decode(
 	if (schema) {
 		for (const [key, type] of Object.entries(schema)) {
 			if (type === 'boolean') {
-				const keys = key.split('.');
+				const keys = splitKey(key);
 				let current = result;
 				for (let i = 0; i < keys.length; i++) {
 					const part = keys[i];

--- a/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
@@ -1,7 +1,8 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { createHistoryEntry } from '$lib/data/history';
-import { uploadRecord } from '$lib/data/multipart';
+import { uploadRecord, nestRecordFields } from '$lib/data/multipart';
 import { createVehicleReminder } from '$lib/data/reminders';
+import { decode } from '$lib/utils/form';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -13,18 +14,23 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 export const actions = {
 	record: async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const date = formData.get('date')?.toString();
-		const notes = formData.get('notes')?.toString() ?? '';
+		const data = decode(formData, {
+			date: 'string',
+			notes: 'string',
+			mileage: 'number',
+			cost: 'number'
+		});
 
-		if (!date) {
+		if (!data.date) {
 			return fail(400, { errors: [{ id: 'date', title: 'Date is required' }] });
 		}
-		if (!notes) {
+		if (!data.notes) {
 			return fail(400, { errors: [{ id: 'notes', title: 'Notes is required' }] });
 		}
 
 		try {
-			await uploadRecord(params.id!, undefined, formData, locals);
+			const nested = nestRecordFields(formData);
+			await uploadRecord(params.id!, undefined, nested, locals);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Upload failed';
 			return fail(422, {
@@ -37,22 +43,24 @@ export const actions = {
 
 	reminder: async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const notes = formData.get('notes')?.toString();
-		const reminderType = formData.get('reminderType')?.toString() ?? '';
-		const date = formData.get('date')?.toString();
-		const mileage = formData.get('mileage')?.toString();
+		const data = decode(formData, {
+			notes: 'string',
+			reminderType: 'string',
+			date: 'string',
+			mileage: 'number'
+		});
 
-		if (!notes) {
+		if (!data.notes) {
 			return fail(400, { errors: [{ id: 'notes', title: 'Note is required' }] });
 		}
 
 		await createVehicleReminder(
 			params.id!,
 			{
-				notes,
-				reminderType: reminderType || null,
-				date: date || null,
-				mileage: mileage ? Number(mileage) : null
+				notes: data.notes as string,
+				reminderType: (data.reminderType as string) || null,
+				date: (data.date as string) || null,
+				mileage: typeof data.mileage === 'number' ? data.mileage : null
 			} as never,
 			locals
 		);
@@ -62,9 +70,9 @@ export const actions = {
 
 	'mileage-adjustment': async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const mileage = formData.get('mileage')?.toString();
+		const data = decode(formData, { mileage: 'number' });
 
-		if (!mileage) {
+		if (typeof data.mileage !== 'number') {
 			return fail(400, { errors: [{ id: 'mileage', title: 'Mileage is required' }] });
 		}
 
@@ -74,7 +82,7 @@ export const actions = {
 			{
 				date: new Date().toISOString().split('T')[0],
 				notes: 'Mileage adjustment',
-				mileage: Number(mileage),
+				mileage: data.mileage,
 				recordType: 'mileage adjustment'
 			} as never,
 			locals

--- a/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
@@ -1,6 +1,6 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { createHistoryEntry } from '$lib/data/history';
-import { uploadRecord, nestRecordFields } from '$lib/data/multipart';
+import { uploadRecord, toMultipartFormData } from '$lib/data/multipart';
 import { createVehicleReminder } from '$lib/data/reminders';
 import { decode } from '$lib/utils/form';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
@@ -28,9 +28,22 @@ export const actions = {
 			return fail(400, { errors: [{ id: 'notes', title: 'Notes is required' }] });
 		}
 
+		const files = formData.getAll('record[attachments][]') as File[];
+		const body = toMultipartFormData(
+			{
+				date: data.date,
+				notes: data.notes,
+				mileage: typeof data.mileage === 'number' ? data.mileage : null,
+				cost: typeof data.cost === 'number' ? data.cost : null
+			},
+			{ prefix: 'record' }
+		);
+		for (const file of files) {
+			body.append('record[attachments][]', file);
+		}
+
 		try {
-			const nested = nestRecordFields(formData);
-			await uploadRecord(params.id!, undefined, nested, locals);
+			await uploadRecord(params.id!, undefined, body, locals);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Upload failed';
 			return fail(422, {

--- a/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
@@ -1,5 +1,6 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { createHistoryEntry } from '$lib/data/history';
+import { uploadRecord } from '$lib/data/multipart';
 import { createVehicleReminder } from '$lib/data/reminders';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
@@ -12,10 +13,8 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 export const actions = {
 	record: async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const notes = formData.get('notes')?.toString() ?? '';
 		const date = formData.get('date')?.toString();
-		const mileage = formData.get('mileage')?.toString();
-		const cost = formData.get('cost')?.toString();
+		const notes = formData.get('notes')?.toString() ?? '';
 
 		if (!date) {
 			return fail(400, { errors: [{ id: 'date', title: 'Date is required' }] });
@@ -24,16 +23,14 @@ export const actions = {
 			return fail(400, { errors: [{ id: 'notes', title: 'Notes is required' }] });
 		}
 
-		await createHistoryEntry(
-			params.id!,
-			{
-				date,
-				notes,
-				mileage: mileage ? Number(mileage) : null,
-				cost: cost || null
-			} as never,
-			locals
-		);
+		try {
+			await uploadRecord(params.id!, undefined, formData, locals);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Upload failed';
+			return fail(422, {
+				errors: [{ id: 'form', title: message }]
+			});
+		}
 
 		redirect(303, `/vehicles/${params.id}`);
 	},
@@ -71,6 +68,7 @@ export const actions = {
 			return fail(400, { errors: [{ id: 'mileage', title: 'Mileage is required' }] });
 		}
 
+		// Mileage-only adjustment doesn't expose attachment UI, so keep the JSON path.
 		await createHistoryEntry(
 			params.id!,
 			{

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
@@ -1,6 +1,7 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { getHistoryEntry } from '$lib/data/history';
-import { uploadRecord, deleteAttachment, nestRecordFields } from '$lib/data/multipart';
+import { uploadRecord, deleteAttachment, toMultipartFormData } from '$lib/data/multipart';
+import { decode } from '$lib/utils/form';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -13,13 +14,17 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 export const actions = {
 	update: async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const date = formData.get('date')?.toString();
-		const notes = formData.get('notes')?.toString() ?? '';
+		const data = decode(formData, {
+			date: 'string',
+			notes: 'string',
+			mileage: 'number',
+			cost: 'number'
+		});
 
-		if (!date) {
+		if (!data.date) {
 			return fail(400, { errors: [{ id: 'date', title: 'Date is required' }] });
 		}
-		if (!notes) {
+		if (!data.notes) {
 			return fail(400, { errors: [{ id: 'notes', title: 'Notes is required' }] });
 		}
 
@@ -29,12 +34,25 @@ export const actions = {
 			.map((s) => s.trim())
 			.filter(Boolean);
 
+		const files = formData.getAll('record[attachments][]') as File[];
+		const body = toMultipartFormData(
+			{
+				date: data.date,
+				notes: data.notes,
+				mileage: typeof data.mileage === 'number' ? data.mileage : null,
+				cost: typeof data.cost === 'number' ? data.cost : null
+			},
+			{ prefix: 'record' }
+		);
+		for (const file of files) {
+			body.append('record[attachments][]', file);
+		}
+
 		try {
 			for (const signedId of toDelete) {
 				await deleteAttachment(params.id!, params.recordId!, signedId, locals);
 			}
-			const nested = nestRecordFields(formData, ['attachments_to_delete']);
-			await uploadRecord(params.id!, params.recordId!, nested, locals);
+			await uploadRecord(params.id!, params.recordId!, body, locals);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Upload failed';
 			return fail(422, {

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
@@ -1,6 +1,6 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { getHistoryEntry } from '$lib/data/history';
-import { uploadRecord, deleteAttachment } from '$lib/data/multipart';
+import { uploadRecord, deleteAttachment, nestRecordFields } from '$lib/data/multipart';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 };
 
 export const actions = {
-	default: async ({ request, locals, params }) => {
+	update: async ({ request, locals, params }) => {
 		const formData = await request.formData();
 		const date = formData.get('date')?.toString();
 		const notes = formData.get('notes')?.toString() ?? '';
@@ -33,7 +33,8 @@ export const actions = {
 			for (const signedId of toDelete) {
 				await deleteAttachment(params.id!, params.recordId!, signedId, locals);
 			}
-			await uploadRecord(params.id!, params.recordId!, formData, locals);
+			const nested = nestRecordFields(formData, ['attachments_to_delete']);
+			await uploadRecord(params.id!, params.recordId!, nested, locals);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : 'Upload failed';
 			return fail(422, {

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
@@ -1,22 +1,20 @@
 import { getVehicle } from '$lib/data/vehicles';
-import { getHistoryEntry, updateHistoryEntry, deleteHistoryEntry } from '$lib/data/history';
+import { getHistoryEntry } from '$lib/data/history';
+import { uploadRecord, deleteAttachment } from '$lib/data/multipart';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals, params }) => {
 	const vehicle = await getVehicle(params.id!, locals);
 	const record = await getHistoryEntry(params.id!, params.recordId!, locals);
-
 	return { vehicle, record };
 };
 
 export const actions = {
 	default: async ({ request, locals, params }) => {
 		const formData = await request.formData();
-		const notes = formData.get('notes')?.toString() ?? '';
 		const date = formData.get('date')?.toString();
-		const mileage = formData.get('mileage')?.toString();
-		const cost = formData.get('cost')?.toString();
+		const notes = formData.get('notes')?.toString() ?? '';
 
 		if (!date) {
 			return fail(400, { errors: [{ id: 'date', title: 'Date is required' }] });
@@ -25,22 +23,31 @@ export const actions = {
 			return fail(400, { errors: [{ id: 'notes', title: 'Notes is required' }] });
 		}
 
-		await updateHistoryEntry(
-			params.id!,
-			params.recordId!,
-			{
-				date,
-				notes,
-				mileage: mileage ? Number(mileage) : null,
-				cost: cost || null
-			} as never,
-			locals
-		);
+		// Process deletions BEFORE update so the multipart PUT doesn't include them.
+		const toDelete = (formData.get('attachments_to_delete')?.toString() ?? '')
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean);
+
+		try {
+			for (const signedId of toDelete) {
+				await deleteAttachment(params.id!, params.recordId!, signedId, locals);
+			}
+			await uploadRecord(params.id!, params.recordId!, formData, locals);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : 'Upload failed';
+			return fail(422, {
+				errors: [{ id: 'form', title: message }]
+			});
+		}
 
 		redirect(303, `/vehicles/${params.id}`);
 	},
 
 	delete: async ({ locals, params }) => {
+		// Note: also need to delete attachments on record delete, but backend
+		// handles this automatically via Active Storage dependent destroy.
+		const { deleteHistoryEntry } = await import('$lib/data/history');
 		await deleteHistoryEntry(params.id!, params.recordId!, locals);
 		redirect(303, `/vehicles/${params.id}`);
 	}

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.svelte
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.svelte
@@ -25,7 +25,7 @@
 	<div class="max-w-2xl mx-auto">
 		<Card variant="outline" bleed>
 			<h1 class="text-xl font-semibold">Edit Record</h1>
-			<RecordForm {vehicle} {record} />
+			<RecordForm {vehicle} {record} action="?/update" />
 		</Card>
 
 		<Card class="mt-6" variant="outline" bleed>

--- a/web-v4/src/routes/vehicles/[id]/transfer/+page.svelte
+++ b/web-v4/src/routes/vehicles/[id]/transfer/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { Button, Card } from '$lib';
+	import FileInput from '$lib/components/forms/FileInput.svelte';
 	import VehiclePageLayout from '$lib/components/vehicles/VehiclePageLayout.svelte';
 	import { page } from '$app/stores';
-	import { Download, Upload } from 'lucide-svelte';
+	import { Download } from 'lucide-svelte';
 	import type { PageProps } from './$types';
 	import { vehiclePath } from '$lib/routes';
 
@@ -45,20 +46,14 @@
 				class="space-y-4"
 			>
 				<label class="flex items-center gap-3 cursor-pointer">
-					<Button variant="outline" as="span">
-						<Upload size={16} />
-						Choose File
-					</Button>
+					<FileInput
+						name="file"
+						accept=".csv"
+						onChange={(input) => (selectedFile = input.files?.[0] ?? null)}
+					/>
 					<span class="text-sm text-ink-400">
 						{selectedFile ? selectedFile.name : 'No file chosen'}
 					</span>
-					<input
-						type="file"
-						name="file"
-						accept=".csv"
-						class="hidden"
-						onchange={(e) => (selectedFile = (e.target as HTMLInputElement).files?.[0] ?? null)}
-					/>
 				</label>
 				<Button type="submit">Import</Button>
 			</form>


### PR DESCRIPTION
## Summary

Frontend for record attachments. Receipts, photos, anything up to 10MB. Backend (Rails Active Storage) already stored files — this wires up the UI: pick files on create/edit, see them inline on the history page, mark any to delete.

## What's in it

- File picker component (`FileInput`) reused across attachment and CSV import flows
- `AttachmentEditor` — mark-for-delete with restore, per-row remove on new files, 10MB client-side guard
- Multipart forwarding to Rails via server actions; old text fields stay flat, decoded server-side
- Attachments show inline in each history row's notes cell (no expand/collapse)
- Existing file links open in a new tab
