### PR TITLE
Validate uploads with magic bytes and size enforcement

### DIFF
--- a/web-v4/src/lib/components/forms/RecordForm.svelte
+++ b/web-v4/src/lib/components/forms/RecordForm.svelte
@@ -26,8 +26,12 @@
 
 	let recordId = record?.id;
 
-	let formErrors = $derived(errors.filter((e) => e.id === 'form'));
-	let attachmentErrors = $derived(errors.filter((e) => e.id === 'attachments'));
+	// Merge page-provided errors (from SvelteKit form prop) with action errors
+	// set by the custom fetch handler below.
+	let actionErrors = $state<FormError[]>([]);
+	let allErrors = $derived([...errors, ...actionErrors]);
+	let formErrors = $derived(allErrors.filter((e) => e.id === 'form'));
+	let attachmentErrors = $derived(allErrors.filter((e) => e.id === 'attachments'));
 
 	let date = $state(
 		record?.date ? formatDateISO(new Date(record.date)) : formatDateISO(new Date()),
@@ -56,6 +60,7 @@
 	// browser's FileList can't be edited (no per-file removal API).
 	const submit: SubmitFunction = ({ formData, cancel }) => {
 		submitting = true;
+		actionErrors = [];
 		const fd = new FormData();
 		for (const [key, value] of formData.entries()) {
 			if (key.startsWith('record[attachments]')) continue;
@@ -71,15 +76,17 @@
 			headers: { Accept: 'application/json' },
 		})
 			.then(async (response) => {
-				if (response.ok || response.redirected) {
-					goto(`/vehicles/${vehicle.id}`, { invalidateAll: true });
+				const result = await response.json();
+				if (result.type === 'redirect') {
+					await goto(result.location, { invalidateAll: true });
 					return;
 				}
-				// Re-render the page with returned errors so the user sees them.
-				const html = await response.text();
-				document.open();
-				document.write(html);
-				document.close();
+				if (result.type === 'failure' && result.data?.errors) {
+					actionErrors = result.data.errors;
+					return;
+				}
+				// Unexpected response — navigate to vehicle page as fallback.
+				await goto(`/vehicles/${vehicle.id}`, { invalidateAll: true });
 			})
 			.catch(() => {
 				// Network error — leave the user on the form to retry.
@@ -107,21 +114,21 @@
 	{/if}
 
 	<fieldset class="flex flex-col gap-4">
-		<Field name="date" label="Date" {errors} required>
+		<Field name="date" label="Date" errors={allErrors} required>
 			<Input type="date" name="date" bind:value={date} required />
 		</Field>
-		<Field name="notes" label="Notes" {errors} required>
+		<Field name="notes" label="Notes" errors={allErrors} required>
 			<Textarea name="notes" bind:value={notes} required class="min-h-30" />
 		</Field>
 
-		<Field name="mileage" label={MileageLabel(vehicle.distanceUnit)} {errors}>
+		<Field name="mileage" label={MileageLabel(vehicle.distanceUnit)} errors={allErrors}>
 			<InputGroup name="mileage" bind:value={mileage} inputmode="numeric">
 				{#snippet endAddon()}{vehicle.distanceUnit}{/snippet}
 			</InputGroup>
 		</Field>
 
 		{#if vehicle.preferences.enableCost}
-			<Field name="cost" label="Cost" {errors}>
+			<Field name="cost" label="Cost" errors={allErrors}>
 				<InputGroup name="cost" bind:value={cost} inputmode="numeric">
 					{#snippet startAddon()}{getCurrencySymbol()}{/snippet}
 				</InputGroup>

--- a/web-v4/src/lib/utils/file-validation.test.ts
+++ b/web-v4/src/lib/utils/file-validation.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { validateAttachmentFile, validateImportFile, validateAttachments } from './file-validation';
+
+/** Build a File with a specific magic-byte header followed by filler content. */
+function fileFromHeader(name: string, header: number[], size?: number, type = ''): File {
+	const content = new Uint8Array(size ?? header.length);
+	content.set(header);
+	for (let i = header.length; i < content.length; i++) {
+		content[i] = 0x41; // filler
+	}
+	return new File([content], name, { type });
+}
+
+describe('validateAttachmentFile', () => {
+	const MAX_SIZE = 10 * 1024 * 1024;
+
+	it('accepts a valid PDF', async () => {
+		const file = fileFromHeader('doc.pdf', [0x25, 0x50, 0x44, 0x46], 100, 'application/pdf');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('application/pdf');
+	});
+
+	it('accepts a valid JPEG', async () => {
+		const file = fileFromHeader('photo.jpg', [0xff, 0xd8, 0xff], 100, 'image/jpeg');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('image/jpeg');
+	});
+
+	it('accepts a valid PNG', async () => {
+		const file = fileFromHeader(
+			'img.png',
+			[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+			100,
+			'image/png'
+		);
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('image/png');
+	});
+
+	it('accepts a valid GIF', async () => {
+		const file = fileFromHeader('anim.gif', [0x47, 0x49, 0x46, 0x38], 100, 'image/gif');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('image/gif');
+	});
+
+	it('accepts a valid WebP (RIFF + WEBP)', async () => {
+		const header = [
+			0x52, 0x49, 0x46, 0x46, // RIFF
+			0x00, 0x00, 0x00, 0x00, // file size (placeholder)
+			0x57, 0x45, 0x42, 0x50 // WEBP
+		];
+		const file = fileFromHeader('img.webp', header, 100, 'image/webp');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('image/webp');
+	});
+
+	it('rejects RIFF without WEBP brand (e.g. WAV disguised as WebP)', async () => {
+		const header = [
+			0x52, 0x49, 0x46, 0x46, // RIFF
+			0x00, 0x00, 0x00, 0x00,
+			0x57, 0x41, 0x56, 0x45 // WAVE — not WEBP
+		];
+		const file = fileFromHeader('audio.webp', header, 100, 'image/webp');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+	});
+
+	it('accepts a valid HEIC (ftyp + heic brand)', async () => {
+		const header = [
+			0x00, 0x00, 0x00, 0x20, // box size
+			0x66, 0x74, 0x79, 0x70, // ftyp
+			0x68, 0x65, 0x69, 0x63 // heic
+		];
+		const file = fileFromHeader('photo.heic', header, 100, 'image/heic');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+		if (result.valid) expect(result.mime).toBe('image/heic');
+	});
+
+	it('accepts HEIC with mif1 brand', async () => {
+		const header = [
+			0x00, 0x00, 0x00, 0x20,
+			0x66, 0x74, 0x79, 0x70, // ftyp
+			0x6d, 0x69, 0x66, 0x31 // mif1
+		];
+		const file = fileFromHeader('photo.heic', header, 100, 'image/heic');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+	});
+
+	it('rejects ftyp with unknown brand', async () => {
+		const header = [
+			0x00, 0x00, 0x00, 0x20,
+			0x66, 0x74, 0x79, 0x70, // ftyp
+			0x6d, 0x70, 0x34, 0x32 // mp42 — QuickTime, not HEIC
+		];
+		const file = fileFromHeader('video.heic', header, 100, 'image/heic');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+	});
+
+	it('rejects an empty file', async () => {
+		const file = new File([], 'empty.pdf', { type: 'application/pdf' });
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('empty');
+	});
+
+	it('rejects a file exceeding max size', async () => {
+		const file = fileFromHeader('big.pdf', [0x25, 0x50, 0x44, 0x46], 11 * 1024 * 1024);
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('exceeds');
+	});
+
+	it('rejects a ZIP archive', async () => {
+		const file = fileFromHeader('malware.pdf', [0x50, 0x4b, 0x03, 0x04], 100, 'application/pdf');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('archive');
+	});
+
+	it('rejects a GZ archive', async () => {
+		const file = fileFromHeader('payload.pdf', [0x1f, 0x8b], 100, 'application/pdf');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('archive');
+	});
+
+	it('rejects a 7z archive', async () => {
+		const file = fileFromHeader(
+			'archive.pdf',
+			[0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c],
+			100,
+			'application/pdf'
+		);
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('archive');
+	});
+
+	it('rejects an executable disguised as PDF', async () => {
+		// MZ header (Windows PE executable)
+		const file = fileFromHeader('trojan.pdf', [0x4d, 0x5a], 100, 'application/pdf');
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('unrecognized');
+	});
+
+	it('rejects a file with a truncated header', async () => {
+		// Only 2 bytes, not enough for any signature
+		const file = fileFromHeader('short.bin', [0x00, 0x00], 2);
+		const result = await validateAttachmentFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+	});
+});
+
+describe('validateImportFile', () => {
+	const MAX_SIZE = 10 * 1024 * 1024;
+
+	it('accepts a valid CSV file', async () => {
+		const csv = new File(['date,notes,mileage\n2024-01-01,Oil change,5000\n'], 'import.csv', {
+			type: 'text/csv'
+		});
+		const result = await validateImportFile(csv, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(true);
+	});
+
+	it('rejects an empty file', async () => {
+		const file = new File([], 'empty.csv');
+		const result = await validateImportFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('empty');
+	});
+
+	it('rejects an oversized file', async () => {
+		const file = fileFromHeader('big.csv', [0x64, 0x61, 0x74, 0x65], 11 * 1024 * 1024);
+		const result = await validateImportFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('exceeds');
+	});
+
+	it('rejects a ZIP archive', async () => {
+		const file = fileFromHeader('import.csv', [0x50, 0x4b, 0x03, 0x04], 100, 'text/csv');
+		const result = await validateImportFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('archive');
+	});
+
+	it('rejects a PDF disguised as CSV', async () => {
+		const file = fileFromHeader('import.csv', [0x25, 0x50, 0x44, 0x46], 100, 'text/csv');
+		const result = await validateImportFile(file, { maxSize: MAX_SIZE });
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('application/pdf');
+	});
+});
+
+describe('validateAttachments', () => {
+	it('accepts multiple valid files under the limit', async () => {
+		const files = [
+			fileFromHeader('a.pdf', [0x25, 0x50, 0x44, 0x46], 100),
+			fileFromHeader('b.jpg', [0xff, 0xd8, 0xff], 100)
+		];
+		const result = await validateAttachments(files);
+		expect(result.valid).toBe(true);
+	});
+
+	it('rejects more than 10 files', async () => {
+		const files = Array.from({ length: 11 }, (_, i) =>
+			fileFromHeader(`file${i}.pdf`, [0x25, 0x50, 0x44, 0x46], 100)
+		);
+		const result = await validateAttachments(files);
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('Maximum 10');
+	});
+
+	it('returns the first invalid file error', async () => {
+		const files = [
+			fileFromHeader('good.pdf', [0x25, 0x50, 0x44, 0x46], 100),
+			fileFromHeader('bad.exe', [0x4d, 0x5a], 100)
+		];
+		const result = await validateAttachments(files);
+		expect(result.valid).toBe(false);
+		if (!result.valid) expect(result.reason).toContain('bad.exe');
+	});
+
+	it('accepts an empty array', async () => {
+		const result = await validateAttachments([]);
+		expect(result.valid).toBe(true);
+	});
+});

--- a/web-v4/src/lib/utils/file-validation.ts
+++ b/web-v4/src/lib/utils/file-validation.ts
@@ -1,13 +1,56 @@
-const MAGIC_BYTES: Record<string, Uint8Array[]> = {
-	// Documents
-	'application/pdf': [new Uint8Array([0x25, 0x50, 0x44, 0x46])], // %PDF
-	// Images
-	'image/jpeg': [new Uint8Array([0xff, 0xd8, 0xff])],
-	'image/png': [new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
-	'image/gif': [new Uint8Array([0x47, 0x49, 0x46, 0x38])], // GIF8
-	'image/webp': [new Uint8Array([0x52, 0x49, 0x46, 0x46])], // RIFF (WebP container)
-	'image/heic': [new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70])], // ftyp box
-};
+const MAX_FILES = 10;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+type MagicSignature = { bytes: Uint8Array; offset: number };
+
+interface MagicEntry {
+	mime: string;
+	// ALL required signatures must match
+	required: MagicSignature[];
+	// If set, at least one alternative signature must also match (at given offset)
+	anyOf?: { signatures: Uint8Array[]; offset: number };
+}
+
+const MAGIC_BYTES: MagicEntry[] = [
+	{
+		mime: 'application/pdf',
+		required: [{ bytes: new Uint8Array([0x25, 0x50, 0x44, 0x46]), offset: 0 }] // %PDF
+	},
+	{
+		mime: 'image/jpeg',
+		required: [{ bytes: new Uint8Array([0xff, 0xd8, 0xff]), offset: 0 }]
+	},
+	{
+		mime: 'image/png',
+		required: [
+			{ bytes: new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), offset: 0 }
+		]
+	},
+	{
+		mime: 'image/gif',
+		required: [{ bytes: new Uint8Array([0x47, 0x49, 0x46, 0x38]), offset: 0 }] // GIF8
+	},
+	{
+		mime: 'image/webp',
+		required: [
+			{ bytes: new Uint8Array([0x52, 0x49, 0x46, 0x46]), offset: 0 }, // RIFF
+			{ bytes: new Uint8Array([0x57, 0x45, 0x42, 0x50]), offset: 8 } // WEBP
+		]
+	},
+	{
+		mime: 'image/heic',
+		required: [{ bytes: new Uint8Array([0x66, 0x74, 0x79, 0x70]), offset: 4 }], // ftyp
+		anyOf: {
+			offset: 8,
+			signatures: [
+				new Uint8Array([0x68, 0x65, 0x69, 0x63]), // heic
+				new Uint8Array([0x68, 0x65, 0x69, 0x78]), // heix
+				new Uint8Array([0x6d, 0x69, 0x66, 0x31]), // mif1
+				new Uint8Array([0x68, 0x65, 0x76, 0x63]) // hevc
+			]
+		}
+	}
+];
 
 const ARCHIVE_SIGNATURES: Uint8Array[] = [
 	new Uint8Array([0x50, 0x4b, 0x03, 0x04]), // ZIP
@@ -16,22 +59,30 @@ const ARCHIVE_SIGNATURES: Uint8Array[] = [
 	new Uint8Array([0x1f, 0x8b]), // GZ
 	new Uint8Array([0x42, 0x5a, 0x68]), // BZ2
 	new Uint8Array([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]), // 7z
-	new Uint8Array([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07]), // RAR
+	new Uint8Array([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07]) // RAR
 ];
 
-function bytesMatch(data: Uint8Array, signature: Uint8Array): boolean {
-	if (data.length < signature.length) return false;
+function bytesMatch(data: Uint8Array, signature: Uint8Array, offset = 0): boolean {
+	if (data.length < offset + signature.length) return false;
 	for (let i = 0; i < signature.length; i++) {
-		if (data[i] !== signature[i]) return false;
+		if (data[offset + i] !== signature[i]) return false;
 	}
 	return true;
 }
 
 function detectMimeType(data: Uint8Array): string | null {
-	for (const [mime, signatures] of Object.entries(MAGIC_BYTES)) {
-		for (const sig of signatures) {
-			if (bytesMatch(data, sig)) return mime;
+	for (const entry of MAGIC_BYTES) {
+		const requiredMatch = entry.required.every((s) => bytesMatch(data, s.bytes, s.offset));
+		if (!requiredMatch) continue;
+
+		if (entry.anyOf) {
+			if (entry.anyOf.signatures.some((sig) => bytesMatch(data, sig, entry.anyOf!.offset))) {
+				return entry.mime;
+			}
+			continue;
 		}
+
+		return entry.mime;
 	}
 	return null;
 }
@@ -40,14 +91,14 @@ function isArchive(data: Uint8Array): boolean {
 	return ARCHIVE_SIGNATURES.some((sig) => bytesMatch(data, sig));
 }
 
-export type FileValidationError = {
-	reason: string;
-};
+export type ValidationResult =
+	| { valid: true; mime: string }
+	| { valid: false; reason: string };
 
 export async function validateAttachmentFile(
 	file: File,
 	options?: { maxSize?: number }
-): Promise<{ valid: true; mime: string } | { valid: false; reason: string }> {
+): Promise<ValidationResult> {
 	if (file.size === 0) {
 		return { valid: false, reason: `"${file.name}" is empty` };
 	}
@@ -55,7 +106,7 @@ export async function validateAttachmentFile(
 	if (options?.maxSize && file.size > options.maxSize) {
 		return {
 			valid: false,
-			reason: `"${file.name}" exceeds ${formatBytes(options.maxSize)} limit`,
+			reason: `"${file.name}" exceeds ${formatBytes(options.maxSize)} limit`
 		};
 	}
 
@@ -66,7 +117,7 @@ export async function validateAttachmentFile(
 	if (isArchive(data)) {
 		return {
 			valid: false,
-			reason: `"${file.name}" is an archive file (ZIP, GZ, etc.) which is not allowed`,
+			reason: `"${file.name}" is an archive file (ZIP, GZ, etc.) which is not allowed`
 		};
 	}
 
@@ -74,7 +125,7 @@ export async function validateAttachmentFile(
 	if (!detected) {
 		return {
 			valid: false,
-			reason: `"${file.name}" has an unrecognized file type. Allowed: PDF, JPEG, PNG, GIF, WebP, HEIC`,
+			reason: `"${file.name}" has an unrecognized file type. Allowed: PDF, JPEG, PNG, GIF, WebP, HEIC`
 		};
 	}
 
@@ -92,7 +143,7 @@ export async function validateImportFile(
 	if (options?.maxSize && file.size > options.maxSize) {
 		return {
 			valid: false,
-			reason: `Import file exceeds ${formatBytes(options.maxSize)} limit`,
+			reason: `Import file exceeds ${formatBytes(options.maxSize)} limit`
 		};
 	}
 
@@ -103,7 +154,7 @@ export async function validateImportFile(
 	if (isArchive(data)) {
 		return {
 			valid: false,
-			reason: 'Import file is an archive (ZIP, GZ, etc.) which is not allowed',
+			reason: 'Import file is an archive (ZIP, GZ, etc.) which is not allowed'
 		};
 	}
 
@@ -112,8 +163,33 @@ export async function validateImportFile(
 	if (detected) {
 		return {
 			valid: false,
-			reason: `Import file appears to be a ${detected} file, not a CSV`,
+			reason: `Import file appears to be a ${detected} file, not a CSV`
 		};
+	}
+
+	return { valid: true };
+}
+
+/**
+ * Validate a batch of attachment files (file count + per-file validation).
+ * Returns the first validation error encountered, or null if all files are valid.
+ */
+export async function validateAttachments(
+	files: File[],
+	options?: { maxSize?: number; maxFiles?: number }
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+	const maxFiles = options?.maxFiles ?? MAX_FILES;
+	const maxSize = options?.maxSize ?? MAX_FILE_SIZE;
+
+	if (files.length > maxFiles) {
+		return { valid: false, reason: `Maximum ${maxFiles} files per record` };
+	}
+
+	for (const file of files) {
+		const result = await validateAttachmentFile(file, { maxSize });
+		if (!result.valid) {
+			return result;
+		}
 	}
 
 	return { valid: true };

--- a/web-v4/src/lib/utils/file-validation.ts
+++ b/web-v4/src/lib/utils/file-validation.ts
@@ -1,0 +1,129 @@
+const MAGIC_BYTES: Record<string, Uint8Array[]> = {
+	// Documents
+	'application/pdf': [new Uint8Array([0x25, 0x50, 0x44, 0x46])], // %PDF
+	// Images
+	'image/jpeg': [new Uint8Array([0xff, 0xd8, 0xff])],
+	'image/png': [new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])],
+	'image/gif': [new Uint8Array([0x47, 0x49, 0x46, 0x38])], // GIF8
+	'image/webp': [new Uint8Array([0x52, 0x49, 0x46, 0x46])], // RIFF (WebP container)
+	'image/heic': [new Uint8Array([0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70])], // ftyp box
+};
+
+const ARCHIVE_SIGNATURES: Uint8Array[] = [
+	new Uint8Array([0x50, 0x4b, 0x03, 0x04]), // ZIP
+	new Uint8Array([0x50, 0x4b, 0x05, 0x06]), // ZIP (empty)
+	new Uint8Array([0x50, 0x4b, 0x07, 0x08]), // ZIP (spanned)
+	new Uint8Array([0x1f, 0x8b]), // GZ
+	new Uint8Array([0x42, 0x5a, 0x68]), // BZ2
+	new Uint8Array([0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]), // 7z
+	new Uint8Array([0x52, 0x61, 0x72, 0x21, 0x1a, 0x07]), // RAR
+];
+
+function bytesMatch(data: Uint8Array, signature: Uint8Array): boolean {
+	if (data.length < signature.length) return false;
+	for (let i = 0; i < signature.length; i++) {
+		if (data[i] !== signature[i]) return false;
+	}
+	return true;
+}
+
+function detectMimeType(data: Uint8Array): string | null {
+	for (const [mime, signatures] of Object.entries(MAGIC_BYTES)) {
+		for (const sig of signatures) {
+			if (bytesMatch(data, sig)) return mime;
+		}
+	}
+	return null;
+}
+
+function isArchive(data: Uint8Array): boolean {
+	return ARCHIVE_SIGNATURES.some((sig) => bytesMatch(data, sig));
+}
+
+export type FileValidationError = {
+	reason: string;
+};
+
+export async function validateAttachmentFile(
+	file: File,
+	options?: { maxSize?: number }
+): Promise<{ valid: true; mime: string } | { valid: false; reason: string }> {
+	if (file.size === 0) {
+		return { valid: false, reason: `"${file.name}" is empty` };
+	}
+
+	if (options?.maxSize && file.size > options.maxSize) {
+		return {
+			valid: false,
+			reason: `"${file.name}" exceeds ${formatBytes(options.maxSize)} limit`,
+		};
+	}
+
+	// Read first 16 bytes for magic byte detection
+	const header = await file.slice(0, 16).arrayBuffer();
+	const data = new Uint8Array(header);
+
+	if (isArchive(data)) {
+		return {
+			valid: false,
+			reason: `"${file.name}" is an archive file (ZIP, GZ, etc.) which is not allowed`,
+		};
+	}
+
+	const detected = detectMimeType(data);
+	if (!detected) {
+		return {
+			valid: false,
+			reason: `"${file.name}" has an unrecognized file type. Allowed: PDF, JPEG, PNG, GIF, WebP, HEIC`,
+		};
+	}
+
+	return { valid: true, mime: detected };
+}
+
+export async function validateImportFile(
+	file: File,
+	options?: { maxSize?: number }
+): Promise<{ valid: true } | { valid: false; reason: string }> {
+	if (file.size === 0) {
+		return { valid: false, reason: 'Import file is empty' };
+	}
+
+	if (options?.maxSize && file.size > options.maxSize) {
+		return {
+			valid: false,
+			reason: `Import file exceeds ${formatBytes(options.maxSize)} limit`,
+		};
+	}
+
+	// Read first 16 bytes to check for binary/archive signatures
+	const header = await file.slice(0, 16).arrayBuffer();
+	const data = new Uint8Array(header);
+
+	if (isArchive(data)) {
+		return {
+			valid: false,
+			reason: 'Import file is an archive (ZIP, GZ, etc.) which is not allowed',
+		};
+	}
+
+	// Reject if it matches known binary formats (not CSV)
+	const detected = detectMimeType(data);
+	if (detected) {
+		return {
+			valid: false,
+			reason: `Import file appears to be a ${detected} file, not a CSV`,
+		};
+	}
+
+	return { valid: true };
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes === 0) return '0 B';
+	const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+	const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+	const value = bytes / Math.pow(1024, i);
+	const decimals = i === 0 ? 0 : i <= 2 ? 1 : 2;
+	return `${value.toFixed(decimals)} ${units[i]}`;
+}

--- a/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
@@ -4,6 +4,7 @@ import { uploadRecord, toMultipartFormData } from '$lib/data/multipart';
 import { createVehicleReminder, deleteReminder } from '$lib/data/reminders';
 import { decode } from '$lib/utils/form';
 import { getHTTPErrors } from '$lib/utils/actions';
+import { validateAttachmentFile } from '$lib/utils/file-validation';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -37,6 +38,28 @@ export const actions = {
 		const reminderId = url.searchParams.get('reminder_id');
 
 		const files = formData.getAll('record[attachments][]') as File[];
+
+		if (files.length > 10) {
+			return fail(422, {
+				errors: [{ id: 'attachments', title: 'Maximum 10 files per record' }]
+			});
+		}
+
+		// Validate file types server-side (magic bytes + fork bomb prevention)
+		for (const file of files) {
+			if (file.size === 0) {
+				return fail(422, {
+					errors: [{ id: 'attachments', title: `"${file.name}" is empty` }]
+				});
+			}
+			const result = await validateAttachmentFile(file, { maxSize: 10 * 1024 * 1024 });
+			if (!result.valid) {
+				return fail(422, {
+					errors: [{ id: 'attachments', title: result.reason }]
+				});
+			}
+		}
+
 		const body = toMultipartFormData(
 			{
 				date: data.date,

--- a/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/add/+page.server.ts
@@ -4,7 +4,7 @@ import { uploadRecord, toMultipartFormData } from '$lib/data/multipart';
 import { createVehicleReminder, deleteReminder } from '$lib/data/reminders';
 import { decode } from '$lib/utils/form';
 import { getHTTPErrors } from '$lib/utils/actions';
-import { validateAttachmentFile } from '$lib/utils/file-validation';
+import { validateAttachments } from '$lib/utils/file-validation';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -39,25 +39,12 @@ export const actions = {
 
 		const files = formData.getAll('record[attachments][]') as File[];
 
-		if (files.length > 10) {
+		// Validate file count, types, and sizes server-side
+		const validation = await validateAttachments(files);
+		if (!validation.valid) {
 			return fail(422, {
-				errors: [{ id: 'attachments', title: 'Maximum 10 files per record' }]
+				errors: [{ id: 'attachments', title: validation.reason }]
 			});
-		}
-
-		// Validate file types server-side (magic bytes + fork bomb prevention)
-		for (const file of files) {
-			if (file.size === 0) {
-				return fail(422, {
-					errors: [{ id: 'attachments', title: `"${file.name}" is empty` }]
-				});
-			}
-			const result = await validateAttachmentFile(file, { maxSize: 10 * 1024 * 1024 });
-			if (!result.valid) {
-				return fail(422, {
-					errors: [{ id: 'attachments', title: result.reason }]
-				});
-			}
 		}
 
 		const body = toMultipartFormData(

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
@@ -2,7 +2,7 @@ import { getVehicle } from '$lib/data/vehicles';
 import { getHistoryEntry } from '$lib/data/history';
 import { uploadRecord, deleteAttachment, toMultipartFormData } from '$lib/data/multipart';
 import { decode } from '$lib/utils/form';
-import { validateAttachmentFile } from '$lib/utils/file-validation';
+import { validateAttachments } from '$lib/utils/file-validation';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -42,25 +42,12 @@ export const actions = {
 
 		const files = formData.getAll('record[attachments][]') as File[];
 
-		if (files.length > 10) {
+		// Validate file count, types, and sizes server-side
+		const validation = await validateAttachments(files);
+		if (!validation.valid) {
 			return fail(422, {
-				errors: [{ id: 'attachments', title: 'Maximum 10 files per record' }]
+				errors: [{ id: 'attachments', title: validation.reason }]
 			});
-		}
-
-		// Validate file types server-side (magic bytes + fork bomb prevention)
-		for (const file of files) {
-			if (file.size === 0) {
-				return fail(422, {
-					errors: [{ id: 'attachments', title: `"${file.name}" is empty` }]
-				});
-			}
-			const result = await validateAttachmentFile(file, { maxSize: 10 * 1024 * 1024 });
-			if (!result.valid) {
-				return fail(422, {
-					errors: [{ id: 'attachments', title: result.reason }]
-				});
-			}
 		}
 
 		const body = toMultipartFormData(

--- a/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts
@@ -2,6 +2,7 @@ import { getVehicle } from '$lib/data/vehicles';
 import { getHistoryEntry } from '$lib/data/history';
 import { uploadRecord, deleteAttachment, toMultipartFormData } from '$lib/data/multipart';
 import { decode } from '$lib/utils/form';
+import { validateAttachmentFile } from '$lib/utils/file-validation';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -40,6 +41,28 @@ export const actions = {
 			.filter(Boolean);
 
 		const files = formData.getAll('record[attachments][]') as File[];
+
+		if (files.length > 10) {
+			return fail(422, {
+				errors: [{ id: 'attachments', title: 'Maximum 10 files per record' }]
+			});
+		}
+
+		// Validate file types server-side (magic bytes + fork bomb prevention)
+		for (const file of files) {
+			if (file.size === 0) {
+				return fail(422, {
+					errors: [{ id: 'attachments', title: `"${file.name}" is empty` }]
+				});
+			}
+			const result = await validateAttachmentFile(file, { maxSize: 10 * 1024 * 1024 });
+			if (!result.valid) {
+				return fail(422, {
+					errors: [{ id: 'attachments', title: result.reason }]
+				});
+			}
+		}
+
 		const body = toMultipartFormData(
 			{
 				date: data.date,

--- a/web-v4/src/routes/vehicles/[id]/transfer/+page.server.ts
+++ b/web-v4/src/routes/vehicles/[id]/transfer/+page.server.ts
@@ -1,5 +1,6 @@
 import { getVehicle } from '$lib/data/vehicles';
 import { importRecords } from '$lib/data/multipart';
+import { validateImportFile } from '$lib/utils/file-validation';
 import { fail, redirect, type Actions } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -11,6 +12,20 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 export const actions = {
 	import: async ({ request, locals, params }) => {
 		const formData = await request.formData();
+		const file = formData.get('vehicle[import_file]') as File | null;
+
+		if (!file || file.size === 0) {
+			return fail(422, {
+				errors: [{ id: 'form', title: 'Please select a CSV file to import' }]
+			});
+		}
+
+		const validation = await validateImportFile(file, { maxSize: 10 * 1024 * 1024 });
+		if (!validation.valid) {
+			return fail(422, {
+				errors: [{ id: 'form', title: validation.reason }]
+			});
+		}
 
 		try {
 			await importRecords(params.id!, formData, locals);


### PR DESCRIPTION
## Summary

Adds server-side file validation for all upload endpoints (record create, record edit, CSV import).

## Changes

- **Magic byte detection** — reads first 16 bytes of each file, validates against known signatures for PDF, JPEG, PNG, GIF, WebP, HEIC. Rejects disguised executables and unknown formats.
- **Fork bomb prevention** — rejects archive formats (ZIP, GZ, BZ2, 7z, RAR) by signature before they reach the backend.
- **Server-side size enforcement** — 10MB limit enforced server-side. Previously only checked in the browser; oversized files were silently accepted.
- **File count limit** — max 10 files per record.
- **Import CSV validation** — rejects empty, oversized, binary, and archive files before forwarding to the backend.

## Files

- `src/lib/utils/file-validation.ts` — new utility for magic byte detection and archive rejection
- `src/routes/vehicles/[id]/add/+page.server.ts` — validate attachments on record create
- `src/routes/vehicles/[id]/history/[recordId]/edit/+page.server.ts` — validate attachments on record edit
- `src/routes/vehicles/[id]/transfer/+page.server.ts` — validate import CSV