### PR TITLE
Web url standardization

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -33,6 +33,11 @@ class ApplicationController < ActionController::API
 
   attr_reader :current_user, :current_session
 
+  def web_base_url
+    request.headers['X-Web-URL'].presence || Rails.application.config.x.web_url
+  end
+  helper_method :web_base_url
+
   def authenticate
     authenticate_token || render_unauthorized
   end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -36,7 +36,6 @@ class ApplicationController < ActionController::API
   def web_base_url
     request.headers['X-Web-URL'].presence || Rails.application.config.x.web_url
   end
-  helper_method :web_base_url
 
   def authenticate
     authenticate_token || render_unauthorized

--- a/api/app/controllers/v2/logins_controller.rb
+++ b/api/app/controllers/v2/logins_controller.rb
@@ -60,7 +60,7 @@ module V2
       if params[:platform] == 'mobile'
         LoginMailer.login_token(user).deliver_later
       else
-        LoginMailer.login_link(user).deliver_later
+        LoginMailer.login_link(user, web_url: web_base_url).deliver_later
       end
     end
   end

--- a/api/app/controllers/v2/logins_controller.rb
+++ b/api/app/controllers/v2/logins_controller.rb
@@ -60,7 +60,7 @@ module V2
       if params[:platform] == 'mobile'
         LoginMailer.login_token(user).deliver_later
       else
-        LoginMailer.login_link(user, host: params[:host]).deliver_later
+        LoginMailer.login_link(user).deliver_later
       end
     end
   end

--- a/api/app/controllers/v2/logins_controller.rb
+++ b/api/app/controllers/v2/logins_controller.rb
@@ -9,6 +9,7 @@ module V2
     def create
       email = params[:email].to_s.strip.downcase
       password = params[:password].presence
+      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
 
       user = User.unscoped.find_by(email: email)
 

--- a/api/app/controllers/v2/logins_controller.rb
+++ b/api/app/controllers/v2/logins_controller.rb
@@ -9,7 +9,6 @@ module V2
     def create
       email = params[:email].to_s.strip.downcase
       password = params[:password].presence
-      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
 
       user = User.unscoped.find_by(email: email)
 

--- a/api/app/controllers/v2/passwords_controller.rb
+++ b/api/app/controllers/v2/passwords_controller.rb
@@ -23,7 +23,7 @@ module V2
       email = params[:email].to_s.strip.downcase
       user = User.unscoped.find_by(email: email)
 
-      PasswordMailer.reset_link(user).deliver_later if user&.password_enabled?
+      PasswordMailer.reset_link(user, web_url: web_base_url).deliver_later if user&.password_enabled?
 
       head :accepted
     end

--- a/api/app/controllers/v2/sessions_controller.rb
+++ b/api/app/controllers/v2/sessions_controller.rb
@@ -65,7 +65,7 @@ module V2
       if params[:platform] == 'mobile'
         LoginMailer.login_token(user).deliver_later
       else
-        LoginMailer.login_link(user).deliver_later
+        LoginMailer.login_link(user, web_url: web_base_url).deliver_later
       end
     end
   end

--- a/api/app/controllers/v2/sessions_controller.rb
+++ b/api/app/controllers/v2/sessions_controller.rb
@@ -14,7 +14,6 @@ module V2
 
     def create
       email = params[:email].strip.downcase
-      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
       user = User.unscoped.find_by(email: email)
 
       user.restore! if user&.deleted?

--- a/api/app/controllers/v2/sessions_controller.rb
+++ b/api/app/controllers/v2/sessions_controller.rb
@@ -14,6 +14,7 @@ module V2
 
     def create
       email = params[:email].strip.downcase
+      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
       user = User.unscoped.find_by(email: email)
 
       user.restore! if user&.deleted?

--- a/api/app/controllers/v2/sessions_controller.rb
+++ b/api/app/controllers/v2/sessions_controller.rb
@@ -14,7 +14,6 @@ module V2
 
     def create
       email = params[:email].strip.downcase
-      host = params[:host]
       user = User.unscoped.find_by(email: email)
 
       user.restore! if user&.deleted?
@@ -25,7 +24,7 @@ module V2
       end
 
       if user
-        issue_login_token(user, host)
+        issue_login_token(user)
         head :no_content
       else
         respond_with_errors(user)
@@ -55,7 +54,7 @@ module V2
 
     private
 
-    def issue_login_token(user, host)
+    def issue_login_token(user)
       login_token = SecureRandom.urlsafe_base64
       user.update!(
         login_token: login_token,
@@ -66,7 +65,7 @@ module V2
       if params[:platform] == 'mobile'
         LoginMailer.login_token(user).deliver_later
       else
-        LoginMailer.login_link(user, host: host).deliver_later
+        LoginMailer.login_link(user).deliver_later
       end
     end
   end

--- a/api/app/controllers/v2/users_controller.rb
+++ b/api/app/controllers/v2/users_controller.rb
@@ -19,6 +19,7 @@ module V2
     # the new address is confirmed via #confirm_email.
     def request_email_change
       new_email = params.dig(:user, :email).to_s.strip
+      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
       return respond_with_error('Email is required', status: :unprocessable_entity) if new_email.blank?
 
       current_user.request_email_change!(new_email)

--- a/api/app/controllers/v2/users_controller.rb
+++ b/api/app/controllers/v2/users_controller.rb
@@ -23,8 +23,7 @@ module V2
 
       current_user.request_email_change!(new_email)
 
-      mailer_host = params[:host].presence || request.base_url
-      EmailChangeMailer.confirm_email(current_user, host: mailer_host).deliver_later
+      EmailChangeMailer.confirm_email(current_user).deliver_later
       EmailChangeMailer.notify_old_email(current_user).deliver_later
 
       head :no_content

--- a/api/app/controllers/v2/users_controller.rb
+++ b/api/app/controllers/v2/users_controller.rb
@@ -19,7 +19,6 @@ module V2
     # the new address is confirmed via #confirm_email.
     def request_email_change
       new_email = params.dig(:user, :email).to_s.strip
-      ActiveSupport::Deprecation.warn("params[:host] is deprecated and will be ignored") if params[:host].present?
       return respond_with_error('Email is required', status: :unprocessable_entity) if new_email.blank?
 
       current_user.request_email_change!(new_email)

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -17,6 +17,4 @@ class ApplicationMailer < ActionMailer::Base
 
     @logo_data_uri = "data:image/png;base64,#{encoded}"
   end
-
-
 end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -25,4 +25,16 @@ class ApplicationMailer < ActionMailer::Base
 
     @logo_data_uri = "data:image/png;base64,#{encoded}"
   end
+
+  def web_preferences_url(token:, vehicle_id: nil)
+    base = @web_url || Rails.application.config.x.web_url
+    path = "/preferences/#{token}"
+    path += "?vehicle_id=#{vehicle_id}" if vehicle_id
+    "#{base}#{path}"
+  end
+
+  def web_reset_password_url(token:)
+    base = @web_url || Rails.application.config.x.web_url
+    "#{base}/reset-password/#{token}"
+  end
 end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -6,7 +6,7 @@ class ApplicationMailer < ActionMailer::Base
   default from: ENV.fetch('FROM_EMAIL', 'noreply@localhost')
   layout 'mailer'
 
-  helper_method :logo_data_uri, :frontend_preferences_url
+  helper_method :logo_data_uri, :web_preferences_url
 
   def logo_data_uri
     return @logo_data_uri if defined?(@logo_data_uri)
@@ -18,10 +18,5 @@ class ApplicationMailer < ActionMailer::Base
     @logo_data_uri = "data:image/png;base64,#{encoded}"
   end
 
-  def frontend_preferences_url(token, vehicle_id: nil)
-    base = ActionMailer::Base.default_url_options[:host].to_s.chomp('/')
-    path = "/preferences/#{token}"
-    path += "?vehicle_id=#{vehicle_id}" if vehicle_id
-    "#{base}#{path}"
-  end
+
 end

--- a/api/app/mailers/application_mailer.rb
+++ b/api/app/mailers/application_mailer.rb
@@ -3,10 +3,18 @@
 class ApplicationMailer < ActionMailer::Base
   include ActionView::Helpers::DateHelper
 
+  attr_reader :web_url
+
   default from: ENV.fetch('FROM_EMAIL', 'noreply@localhost')
   layout 'mailer'
 
   helper_method :logo_data_uri, :web_preferences_url
+
+  def default_url_options
+    base = web_url || Rails.application.config.x.web_url
+    uri = URI.parse(base)
+    { host: uri.host, port: uri.port, protocol: uri.scheme }
+  end
 
   def logo_data_uri
     return @logo_data_uri if defined?(@logo_data_uri)

--- a/api/app/mailers/email_change_mailer.rb
+++ b/api/app/mailers/email_change_mailer.rb
@@ -2,9 +2,8 @@
 
 class EmailChangeMailer < ApplicationMailer
   # Sent to the NEW (unconfirmed) email address with a confirmation link.
-  def confirm_email(user, url_options)
+  def confirm_email(user)
     @user = user
-    @url_options = url_options
     @expires_at = expires_time
     mail to: @user.unconfirmed_email,
          subject: "Confirm your new email for Spanner (expires #{@expires_at})"

--- a/api/app/mailers/login_mailer.rb
+++ b/api/app/mailers/login_mailer.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class LoginMailer < ApplicationMailer
-  def login_link(user, **url_options)
+  def login_link(user)
     @user = user
-    @url_options = url_options
     mail to: @user.email, subject: subject
   end
 

--- a/api/app/mailers/login_mailer.rb
+++ b/api/app/mailers/login_mailer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class LoginMailer < ApplicationMailer
-  def login_link(user)
+  def login_link(user, web_url: nil)
+    @web_url = web_url
     @user = user
     mail to: @user.email, subject: subject
   end

--- a/api/app/mailers/password_mailer.rb
+++ b/api/app/mailers/password_mailer.rb
@@ -3,13 +3,7 @@
 class PasswordMailer < ApplicationMailer
   def reset_link(user)
     @user = user
-    @reset_url = "#{frontend_base_url}/reset-password/#{user.password_reset_token}"
+    @reset_url = web_reset_password_url(token: user.password_reset_token)
     mail to: @user.email, subject: 'Reset your Spanner password'
-  end
-
-  private
-
-  def frontend_base_url
-    ENV.fetch('WEB_URL', ActionMailer::Base.default_url_options[:host].to_s.chomp('/'))
   end
 end

--- a/api/app/mailers/password_mailer.rb
+++ b/api/app/mailers/password_mailer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class PasswordMailer < ApplicationMailer
-  def reset_link(user)
+  def reset_link(user, web_url: nil)
+    @web_url = web_url
     @user = user
     @reset_url = web_reset_password_url(token: user.password_reset_token)
     mail to: @user.email, subject: 'Reset your Spanner password'

--- a/api/app/services/channels/webhook_channel.rb
+++ b/api/app/services/channels/webhook_channel.rb
@@ -81,14 +81,9 @@ class WebhookChannel
   private_class_method :ntfy_reminders_content
 
   def self.vehicle_link(vehicle)
-    "[#{vehicle.name}](#{vehicle_url(vehicle)})"
+    "[#{vehicle.name}](#{Rails.application.config.x.web_url}/vehicles/#{vehicle.id})"
   end
   private_class_method :vehicle_link
-
-  def self.vehicle_url(vehicle)
-    "#{Rails.application.config.x.web_url}/vehicles/#{vehicle.id}"
-  end
-  private_class_method :vehicle_url
 
   def self.base_payload(event, user)
     {

--- a/api/app/views/email_change_mailer/confirm_email.html.erb
+++ b/api/app/views/email_change_mailer/confirm_email.html.erb
@@ -6,7 +6,7 @@
   Click the button below to confirm the new email address.
 </p>
 <p>
-  <%= link_to 'Confirm new email', confirm_email_url(@user.email_confirmation_token, @url_options), class: 'button' %>
+  <%= link_to 'Confirm new email', confirm_email_url(@user.email_confirmation_token), class: 'button' %>
 </p>
 
 <p>

--- a/api/app/views/email_change_mailer/confirm_email.text.erb
+++ b/api/app/views/email_change_mailer/confirm_email.text.erb
@@ -3,7 +3,7 @@ You requested to change the email on your Spanner account from
 
 Confirm the new email address by visiting the link below:
 
-<%= confirm_email_url(@user.email_confirmation_token, @url_options) %>
+<%= confirm_email_url(@user.email_confirmation_token) %>
 
 This link expires <%= @expires_at %> and can only be used once.
 

--- a/api/app/views/layouts/mailer.html.erb
+++ b/api/app/views/layouts/mailer.html.erb
@@ -19,19 +19,17 @@
 
         <%= yield %>
 
-        <% app_url = Rails.configuration.x.web_url %>
         <div class="footer">
           <% if @user && @user.unsubscribed_at.nil? %>
             <div>
                 <small class="text-muted">
-                    <%= link_to 'Manage email preferences', frontend_preferences_url(@user.account_token), class: 'text-muted' %>
+                    <%= link_to 'Manage email preferences', web_preferences_url(token: @user.account_token), class: 'text-muted' %>
                 </small>
             </div>
           <% end %>
           <div>
             <small class="text-muted">
-                View all your vehicles at
-                <%= link_to app_url, app_url, class: 'text-muted' %>
+                <%= link_to 'View all your vehicles', web_root_url, class: 'text-muted' %>
             </small>
           </div>
           <div>

--- a/api/app/views/layouts/mailer.text.erb
+++ b/api/app/views/layouts/mailer.text.erb
@@ -6,11 +6,10 @@ Hello <%= @user.email %>!
 
 <%= yield %>
 
-<% app_url = Rails.configuration.x.web_url %>
 <% if @user && @user.unsubscribed_at.nil? %>
-Manage email preferences: <%= frontend_preferences_url(@user.account_token) %>
+Manage email preferences: <%= web_preferences_url(token: @user.account_token) %>
 <% end %>
 ---
-View all your vehicles at <%= app_url %>
+View all your vehicles at <%= web_root_url %>
 
 Thanks for using Spanner!

--- a/api/app/views/login_mailer/login_link.html.erb
+++ b/api/app/views/login_mailer/login_link.html.erb
@@ -2,7 +2,7 @@
   Click the button below to sign in and see your vehicles.
 </p>
 <p>
-  <%= link_to 'Sign In', login_url(@user.login_token, @url_options), class: 'button' %>
+  <%= link_to 'Sign In', login_url(@user.login_token), class: 'button' %>
 </p>
 
 <p>

--- a/api/app/views/login_mailer/login_link.text.erb
+++ b/api/app/views/login_mailer/login_link.text.erb
@@ -1,6 +1,6 @@
 Click the link below to sign in and see your vehicles.
 
-<%= login_url(@user.login_token, @url_options) %>
+<%= login_url(@user.login_token) %>
 
 Alternatively, copy the token below and paste it in the app.
 

--- a/api/app/views/reminders_mailer/reminder_today.html.erb
+++ b/api/app/views/reminders_mailer/reminder_today.html.erb
@@ -16,7 +16,7 @@
     </ul>
     <p>
         <%= link_to 'View', vehicle_url(vehicle), class: 'button button-small' %>
-        <%= link_to "Manage notifications", frontend_preferences_url(@user.account_token, vehicle_id: vehicle.id), class: 'button button-small button-outline' %>
+        <%= link_to "Manage notifications", web_preferences_url(token: @user.account_token, vehicle_id: vehicle.id), class: 'button button-small button-outline' %>
     </p>
   </div>
 <% end %>

--- a/api/app/views/reminders_mailer/reminder_today.text.erb
+++ b/api/app/views/reminders_mailer/reminder_today.text.erb
@@ -8,7 +8,7 @@ You wanted to be reminded about some things today.
     * <%= reminder.notes %>
   <% end %>
 
-  Manage notifications for <%= vehicle.name %>: <%= frontend_preferences_url(@user.account_token, vehicle_id: vehicle.id) %>
+  Manage notifications for <%= vehicle.name %>: <%= web_preferences_url(token: @user.account_token, vehicle_id: vehicle.id) %>
 
 <% end %>
 

--- a/api/app/views/reminders_mailer/reminder_upcoming.html.erb
+++ b/api/app/views/reminders_mailer/reminder_upcoming.html.erb
@@ -15,6 +15,6 @@
   </ul>
   <p>
     <%= link_to 'View', vehicle_url(vehicle), class: 'button button-small' %>
-    <%= link_to "Manage notifications", frontend_preferences_url(@user.account_token, vehicle_id: vehicle.id), class: 'button button-small button-outline' %>
+    <%= link_to "Manage notifications", web_preferences_url(token: @user.account_token, vehicle_id: vehicle.id), class: 'button button-small button-outline' %>
   </p>
 <% end %>

--- a/api/app/views/reminders_mailer/reminder_upcoming.text.erb
+++ b/api/app/views/reminders_mailer/reminder_upcoming.text.erb
@@ -8,7 +8,7 @@ You have some reminders coming up in <%= time_ago_in_words @date %>.
     * <%= reminder.notes %>
   <% end %>
 
-  Manage notifications for <%= vehicle.name %>: <%= frontend_preferences_url(@user.account_token, vehicle_id: vehicle.id) %>
+  Manage notifications for <%= vehicle.name %>: <%= web_preferences_url(token: @user.account_token, vehicle_id: vehicle.id) %>
 
 <% end %>
 

--- a/api/config/environments/development.rb
+++ b/api/config/environments/development.rb
@@ -49,7 +49,8 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
 
   config.action_mailer.default_url_options = {
-    host: 'http://localhost:5173'
+    host: 'localhost:5173',
+    protocol: 'http'
   }
 
   # Raises error for missing translations

--- a/api/config/environments/test.rb
+++ b/api/config/environments/test.rb
@@ -47,7 +47,8 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   config.action_mailer.default_url_options = {
-    host: 'http://localhost:3000'
+    host: 'localhost:3000',
+    protocol: 'http'
   }
 
   # Raises error for missing translations

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -6,21 +6,21 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   root 'status#index'
 
   direct :web_root do
-    '/'
+    Rails.application.config.x.web_url
   end
 
   direct :web_vehicle, vehicle: nil do |options|
-    "/vehicles/#{options[:vehicle].id}"
+    "#{Rails.application.config.x.web_url}/vehicles/#{options[:vehicle].id}"
   end
 
   direct :web_preferences, token: nil, vehicle_id: nil do |options|
     path = "/preferences/#{options[:token]}"
     path += "?vehicle_id=#{options[:vehicle_id]}" if options[:vehicle_id]
-    path
+    "#{Rails.application.config.x.web_url}#{path}"
   end
 
   direct :web_reset_password, token: nil do |options|
-    "/reset-password/#{options[:token]}"
+    "#{Rails.application.config.x.web_url}/reset-password/#{options[:token]}"
   end
 
   scope module: :v2 do

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -6,21 +6,21 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   root 'status#index'
 
   direct :web_root do
-    Rails.application.config.x.web_url
+    '/'
   end
 
   direct :web_vehicle, vehicle: nil do |options|
-    "#{Rails.application.config.x.web_url}/vehicles/#{options[:vehicle].id}"
+    "/vehicles/#{options[:vehicle].id}"
   end
 
   direct :web_preferences, token: nil, vehicle_id: nil do |options|
     path = "/preferences/#{options[:token]}"
     path += "?vehicle_id=#{options[:vehicle_id]}" if options[:vehicle_id]
-    "#{Rails.application.config.x.web_url}#{path}"
+    path
   end
 
   direct :web_reset_password, token: nil do |options|
-    "#{Rails.application.config.x.web_url}/reset-password/#{options[:token]}"
+    "/reset-password/#{options[:token]}"
   end
 
   scope module: :v2 do

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -5,6 +5,24 @@ require 'constraints/api_constraint'
 Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   root 'status#index'
 
+  direct :web_root do
+    Rails.application.config.x.web_url
+  end
+
+  direct :web_vehicle, vehicle: nil do |options|
+    "#{Rails.application.config.x.web_url}/vehicles/#{options[:vehicle].id}"
+  end
+
+  direct :web_preferences, token: nil, vehicle_id: nil do |options|
+    path = "/preferences/#{options[:token]}"
+    path += "?vehicle_id=#{options[:vehicle_id]}" if options[:vehicle_id]
+    "#{Rails.application.config.x.web_url}#{path}"
+  end
+
+  direct :web_reset_password, token: nil do |options|
+    "#{Rails.application.config.x.web_url}/reset-password/#{options[:token]}"
+  end
+
   scope module: :v2 do
     post 'sessions', to: 'sessions#create'
     post 'login', to: 'logins#create', as: nil

--- a/api/test/mailers/login_mailer_test.rb
+++ b/api/test/mailers/login_mailer_test.rb
@@ -8,7 +8,7 @@ class LoginMailerTest < ActionMailer::TestCase
   end
 
   test 'login_link' do
-    mail = LoginMailer.login_link(@user, host: 'http://localhost')
+    mail = LoginMailer.login_link(@user)
 
     assert_match 'Sign in to Spanner', mail.subject
     assert_equal ['user1@test'], mail.to

--- a/api/test/mailers/previews/email_change_mailer_preview.rb
+++ b/api/test/mailers/previews/email_change_mailer_preview.rb
@@ -9,7 +9,7 @@ class EmailChangeMailerPreview < ActionMailer::Preview
       email_confirmation_token: SecureRandom.urlsafe_base64,
       email_confirmation_token_valid_until: 15.minutes.from_now
     )
-    EmailChangeMailer.confirm_email(user, host: 'localhost:3000', protocol: 'http')
+    EmailChangeMailer.confirm_email(user)
   end
 
   def notify_old_email

--- a/api/test/mailers/prompt_user_mailer_test.rb
+++ b/api/test/mailers/prompt_user_mailer_test.rb
@@ -11,7 +11,7 @@ class PromptUserMailerTest < ActionMailer::TestCase
 
   test 'add_first_vehicle includes preferences link' do
     mail = PromptUserMailer.add_first_vehicle(@user)
-    expected_url = ApplicationMailer.new.frontend_preferences_url(@user.account_token)
+    expected_url = Rails.application.routes.url_helpers.web_preferences_url(token: @user.account_token)
 
     assert_match 'Manage email preferences', mail.html_part.body.to_s
     assert_match expected_url, mail.html_part.body.to_s
@@ -25,7 +25,7 @@ class PromptUserMailerTest < ActionMailer::TestCase
 
   test 'add_record includes preferences link' do
     mail = PromptUserMailer.add_record(@user, @vehicle)
-    expected_url = ApplicationMailer.new.frontend_preferences_url(@user.account_token)
+    expected_url = Rails.application.routes.url_helpers.web_preferences_url(token: @user.account_token)
 
     assert_match 'Manage email preferences', mail.html_part.body.to_s
     assert_match expected_url, mail.html_part.body.to_s
@@ -33,7 +33,7 @@ class PromptUserMailerTest < ActionMailer::TestCase
 
   test 'add_first_record includes preferences link' do
     mail = PromptUserMailer.add_first_record(@user, @vehicle)
-    expected_url = ApplicationMailer.new.frontend_preferences_url(@user.account_token)
+    expected_url = Rails.application.routes.url_helpers.web_preferences_url(token: @user.account_token)
 
     assert_match 'Manage email preferences', mail.html_part.body.to_s
     assert_match expected_url, mail.html_part.body.to_s

--- a/api/test/mailers/reminders_mailer_test.rb
+++ b/api/test/mailers/reminders_mailer_test.rb
@@ -39,7 +39,8 @@ class RemindersMailerTest < ActionMailer::TestCase
 
     mail = RemindersMailer.reminder_today(user, [reminder])
     expected_url = Rails.application.routes.url_helpers.web_preferences_url(token: user.account_token)
-    expected_vehicle_url = Rails.application.routes.url_helpers.web_preferences_url(token: user.account_token, vehicle_id: vehicle.id)
+    expected_vehicle_url = Rails.application.routes.url_helpers.web_preferences_url(token: user.account_token,
+                                                                                    vehicle_id: vehicle.id)
 
     assert_match 'Manage email preferences', mail.html_part.body.to_s
     assert_match expected_url, mail.html_part.body.to_s

--- a/api/test/mailers/reminders_mailer_test.rb
+++ b/api/test/mailers/reminders_mailer_test.rb
@@ -38,8 +38,8 @@ class RemindersMailerTest < ActionMailer::TestCase
     reminder = Reminder.new(notes: 'Oil change', vehicle: vehicle, date: Time.zone.today)
 
     mail = RemindersMailer.reminder_today(user, [reminder])
-    expected_url = ApplicationMailer.new.frontend_preferences_url(user.account_token)
-    expected_vehicle_url = ApplicationMailer.new.frontend_preferences_url(user.account_token, vehicle_id: vehicle.id)
+    expected_url = Rails.application.routes.url_helpers.web_preferences_url(token: user.account_token)
+    expected_vehicle_url = Rails.application.routes.url_helpers.web_preferences_url(token: user.account_token, vehicle_id: vehicle.id)
 
     assert_match 'Manage email preferences', mail.html_part.body.to_s
     assert_match expected_url, mail.html_part.body.to_s

--- a/web-v4/src/app.d.ts
+++ b/web-v4/src/app.d.ts
@@ -8,6 +8,7 @@ declare global {
 		interface Locals {
 			authToken: string | undefined;
 			session: Session | null | undefined;
+			webUrl: string;
 		}
 		// interface PageData {}
 		// interface PageState {}

--- a/web-v4/src/hooks.server.ts
+++ b/web-v4/src/hooks.server.ts
@@ -25,6 +25,7 @@ export const handle: Handle = sequence(Sentry.sentryHandle(), async ({ event, re
 	}
 
 	event.locals.session = session;
+	event.locals.webUrl = event.url.origin;
 	event.locals.authToken = session?.authToken;
 
 	const prefsCookie = event.cookies.get('prefs');

--- a/web-v4/src/lib/components/forms/SigninForm.svelte
+++ b/web-v4/src/lib/components/forms/SigninForm.svelte
@@ -160,6 +160,7 @@
 						block
 						onclick={() => {
 							mode = 'default';
+							password = '';
 							formErrors = [];
 						}}>Back</Button
 					>

--- a/web-v4/src/lib/data/client.ts
+++ b/web-v4/src/lib/data/client.ts
@@ -46,7 +46,7 @@ export function createAPIRequest(initialConfig: FetcherConfig) {
 	};
 
 	return async function fetcher<T>(endpoint: string, options: RequestOpts = {}): Promise<T> {
-		const { authToken, params, ...init } = options;
+		const { authToken, webUrl, params, ...init } = options;
 
 		const url = new URL(
 			config.baseURI + endpoint,
@@ -66,6 +66,10 @@ export function createAPIRequest(initialConfig: FetcherConfig) {
 		const authHeaderValue = config.authHeaderValue(authToken);
 		if (authHeaderValue) {
 			headers.set('Authorization', authHeaderValue);
+		}
+
+		if (webUrl) {
+			headers.set('X-Web-URL', webUrl);
 		}
 
 		if (options.json) {

--- a/web-v4/src/lib/data/session.ts
+++ b/web-v4/src/lib/data/session.ts
@@ -12,33 +12,37 @@ export interface Session {
 	authToken: string;
 }
 
-export const create = async (data: { email: string }) => {
-	return request(`/sessions`, { method: 'POST', json: data });
+export const create = async (data: { email: string }, opts?: RequestOpts) => {
+	return request(`/sessions`, { ...opts, method: 'POST', json: data });
 };
 
 export async function signin(token: string) {
 	return request<Session>(`/login/${token}`);
 }
 
-export const login = async (data: {
-	email: string;
-	password?: string;
-	timeZoneOffset?: string;
-}) => {
+export const login = async (
+	data: {
+		email: string;
+		password?: string;
+		timeZoneOffset?: string;
+	},
+	opts?: RequestOpts
+) => {
 	const { timeZoneOffset, ...body } = data;
 	return request<{ auth_token?: string }>('/login', {
+		...opts,
 		method: 'POST',
 		json: body,
 		headers: timeZoneOffset ? { 'Time-Zone-Offset': timeZoneOffset } : undefined,
 	});
 };
 
-export const requestReset = async (data: { email: string }) => {
-	return request('/password/reset', { method: 'POST', json: data });
+export const requestReset = async (data: { email: string }, opts?: RequestOpts) => {
+	return request('/password/reset', { ...opts, method: 'POST', json: data });
 };
 
-export const resetPassword = async (token: string, data: { password: string }) => {
-	return request<Session>(`/password/reset/${token}`, { method: 'POST', json: data });
+export const resetPassword = async (token: string, data: { password: string }, opts?: RequestOpts) => {
+	return request<Session>(`/password/reset/${token}`, { ...opts, method: 'POST', json: data });
 };
 
 export const setPassword = async (

--- a/web-v4/src/lib/data/session.ts
+++ b/web-v4/src/lib/data/session.ts
@@ -12,7 +12,7 @@ export interface Session {
 	authToken: string;
 }
 
-export const create = async (data: { email: string; host?: string }) => {
+export const create = async (data: { email: string }) => {
 	return request(`/sessions`, { method: 'POST', json: data });
 };
 
@@ -23,7 +23,6 @@ export async function signin(token: string) {
 export const login = async (data: {
 	email: string;
 	password?: string;
-	host?: string;
 	timeZoneOffset?: string;
 }) => {
 	const { timeZoneOffset, ...body } = data;

--- a/web-v4/src/lib/data/settings.ts
+++ b/web-v4/src/lib/data/settings.ts
@@ -2,11 +2,11 @@ import { request } from './server';
 import { updateUser } from './user';
 import type { RequestOpts } from './types';
 
-export const requestEmailChange = (email: string, host: string, opts: RequestOpts) => {
+export const requestEmailChange = (email: string, opts: RequestOpts) => {
 	return request(`/user/email_change`, {
 		...opts,
 		method: 'POST',
-		json: { user: { email }, host },
+		json: { user: { email } },
 	});
 };
 

--- a/web-v4/src/lib/data/types.ts
+++ b/web-v4/src/lib/data/types.ts
@@ -9,6 +9,7 @@ export interface FetcherConfig {
 
 export interface RequestContext {
 	authToken?: string;
+	webUrl?: string;
 	json?: Record<string, unknown>;
 	params?: Record<string, string | number | boolean | undefined | null>;
 }

--- a/web-v4/src/routes/+page.server.ts
+++ b/web-v4/src/routes/+page.server.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_EMAIL_ENABLED, WEB_URL } from '$app/env/private';
+import { PUBLIC_EMAIL_ENABLED } from '$app/env/private';
 import * as session from '$lib/data/session';
 import { fail, redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
@@ -21,7 +21,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions = {
-	login: async ({ request, cookies, url }) => {
+	login: async ({ request, cookies }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, loginSchema);
 
@@ -29,14 +29,12 @@ export const actions = {
 			return fail(401, { errors: parsed.errors });
 		}
 
-		const host = WEB_URL || url.origin;
 		const timeZoneOffset = formData.get('timeZoneOffset') as string | null;
 
 		try {
 			const result = await session.login({
 				email: parsed.data.email,
 				password: parsed.data.password || undefined,
-				host,
 				timeZoneOffset: timeZoneOffset || undefined,
 			});
 
@@ -54,7 +52,7 @@ export const actions = {
 		}
 	},
 
-	magicLink: async ({ request, url }) => {
+	magicLink: async ({ request }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, loginSchema);
 
@@ -62,12 +60,9 @@ export const actions = {
 			return fail(422, { errors: parsed.errors });
 		}
 
-		const host = WEB_URL || url.origin;
-
 		try {
 			await session.login({
 				email: parsed.data.email,
-				host,
 			});
 
 			return { status: 'pending' };

--- a/web-v4/src/routes/+page.server.ts
+++ b/web-v4/src/routes/+page.server.ts
@@ -21,7 +21,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions = {
-	login: async ({ request, cookies }) => {
+	login: async ({ request, cookies, locals }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, loginSchema);
 
@@ -36,7 +36,7 @@ export const actions = {
 				email: parsed.data.email,
 				password: parsed.data.password || undefined,
 				timeZoneOffset: timeZoneOffset || undefined,
-			});
+			}, locals);
 
 			if (result && typeof result === 'object' && 'authToken' in result) {
 				await setSession(cookies, result as session.Session);
@@ -52,7 +52,7 @@ export const actions = {
 		}
 	},
 
-	magicLink: async ({ request }) => {
+	magicLink: async ({ request, locals }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, loginSchema);
 
@@ -63,7 +63,7 @@ export const actions = {
 		try {
 			await session.login({
 				email: parsed.data.email,
-			});
+			}, locals);
 
 			return { status: 'pending' };
 		} catch (error) {

--- a/web-v4/src/routes/reset-password/+page.server.ts
+++ b/web-v4/src/routes/reset-password/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async ({ url }) => {
 };
 
 export const actions = {
-	request: async ({ request }) => {
+	request: async ({ request, locals }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, requestResetSchema);
 
@@ -20,7 +20,7 @@ export const actions = {
 		}
 
 		try {
-			await requestReset({ email: parsed.data.email });
+			await requestReset({ email: parsed.data.email }, locals);
 			return { status: 'pending' };
 		} catch (error) {
 			return fail(422, getHTTPErrors(error));

--- a/web-v4/src/routes/settings/+page.server.ts
+++ b/web-v4/src/routes/settings/+page.server.ts
@@ -1,4 +1,3 @@
-import { WEB_URL } from '$app/env/private';
 import { requestEmailChange, deleteAccount, updateWebhookUrl } from '$lib/data/settings';
 import { setPassword } from '$lib/data/session';
 import { getCurrentUser } from '$lib/data/user';
@@ -18,7 +17,7 @@ export const load: PageServerLoad = async ({ locals }) => {
 };
 
 export const actions = {
-	changeEmail: async ({ request, locals, url }) => {
+	changeEmail: async ({ request, locals }) => {
 		const formData = await request.formData();
 		const parsed = parseForm(formData, changeEmailSchema);
 
@@ -26,10 +25,8 @@ export const actions = {
 			return fail(422, { errors: parsed.errors });
 		}
 
-		const host = WEB_URL || url.origin;
-
 		try {
-			await requestEmailChange(parsed.data.email, host, locals);
+			await requestEmailChange(parsed.data.email, locals);
 			return { emailSuccess: true, email: parsed.data.email };
 		} catch (error) {
 			return fail(422, getHTTPErrors(error));


### PR DESCRIPTION
Standardize frontend URL generation across the stack.

### Problem

The frontend base URL was sourced from three different places (config.x.web_url, default_url_options[:host], ENV.fetch('WEB_URL'')) and constructed using inconsistent patterns (manual string interpolation, Rails route helpers, ad-hoc helpers). Three API endpoints received `host` in the request body to work around this.

### Solution

- **Rails `direct` route helpers** — `web_root_url`, `web_vehicle_url`, `web_preferences_url`, `web_reset_password_url` defined in `config/routes.rb` returning full frontend URLs
- **Request-aware base URL** — `web_base_url` on `ApplicationController` reads `X-Web-URL` header (from SvelteKit), falls back to `config.x.web_url`
- **Mailer cleanup** — removed `frontend_preferences_url` helper and `host:` params from mailer calls; layouts use `web_*` helpers
- **SvelteKit pipeline** — forwards `event.url.origin` as `X-Web-URL` header on all API requests
- **Removed `host` from request bodies** — `session.create`, `session.login`, `settings.requestEmailChange` no longer send `host` param

### Fixes

- Fixed `config.action_mailer.default_url_options` in test/development (host included protocol, causing mailer URL generation to fail)
- Fixed sign-in form back button stuck in password mode (autofill value re-triggered mode switch)

### Notes

`params[:host]` is still silently accepted for backward compatibility but no longer used by any controller.