### PR TITLE
Extract MileageProjection module from Vehicle

### DIFF
--- a/api/app/models/vehicle.rb
+++ b/api/app/models/vehicle.rb
@@ -13,9 +13,6 @@ class Vehicle < ApplicationRecord
 
   default_scope { order(position: :asc, id: :asc) }
 
-  ONE_YEAR = 365
-  WEIGHT_COEFFICIENT = 10
-
   def preferences
     @preferences ||= VehiclePreferences.new(self[:preferences] || {})
   end
@@ -49,140 +46,24 @@ class Vehicle < ApplicationRecord
     vin[0..7] + vin[9..10]
   end
 
-  def estimated_mileage
-    unless can_estimate_mpd?
-      return if first_record_with_mileage.nil?
+  delegate :estimated_mileage, to: :projection
 
-      return first_record_with_mileage.mileage
-    end
+  delegate :estimated_next_record_date, to: :projection
 
-    projected_mileage = round_to(estimated_mileage_exact, 50)
+  delegate :miles_per_day, to: :projection
 
-    return estimated_mileage_exact.round(-1) unless projected_mileage > 50
-
-    projected_mileage
-  end
-
-  def estimated_mileage_exact
-    return unless can_estimate_mpd?
-
-    last_record = last_record_with_mileage
-    (last_record.mileage + (weighted_averge_miles_per_day * elapsed_days(Time.zone.now.beginning_of_day,
-                                                                         last_record.date))).to_i
-  end
-
-  def estimated_next_record_date
-    record = last_record_with_mileage
-    return unless record
-
-    days = weighted_average_days_per_period + elapsed_days(Time.zone.now.beginning_of_day, record.date)
-    record.date + days.days
-  end
-
-  def miles_per_year
-    return unless can_estimate_mpd?
-
-    projected_mileage = round_to(miles_per_year_exact, 500)
-
-    return miles_per_year_exact.round(-2) unless projected_mileage.positive?
-
-    projected_mileage
-  end
-
-  def miles_per_year_exact
-    return unless can_estimate_mpd?
-
-    (weighted_averge_miles_per_day * ONE_YEAR).to_i
-  end
-
-  def periods
-    @periods ||= begin
-      selected = records
-        .unscope(:order)
-        .where.not(mileage: nil)
-        .limit(WEIGHT_COEFFICIENT)
-        .order(date: :desc)
-        .pluck(:date, :mileage)
-
-      results = selected.each_with_index.map do |r, i|
-        previous = selected[i + 1]
-        next unless previous
-
-        n = selected.size - i
-        weight = n * (n - 1) / 2
-
-        period_elapsed_days = elapsed_days(r[0], previous[0])
-        next if period_elapsed_days < 1
-
-        elapsed_miles = r[1] - previous[1]
-
-        {
-          elapsed_days: period_elapsed_days,
-          elapsed_miles: elapsed_miles,
-          miles_per_day: elapsed_miles / period_elapsed_days,
-          weight: weight,
-          weighted_miles_per_day: (elapsed_miles / period_elapsed_days) * weight
-        }
-      end.compact
-
-      results
-    end
-  end
-
-  def miles_per_day
-    weighted_averge_miles_per_day
-  end
-
-  def weighted_average_days_per_period
-    days = periods.map { |p| p[:elapsed_days] * p[:weight] }
-    weights = periods.pluck(:weight)
-
-    weighted_average(days, weights)
-  end
-
-  def weighted_averge_miles_per_day
-    miles = periods.pluck(:weighted_miles_per_day)
-    weights = periods.pluck(:weight)
-
-    weighted_average(miles, weights)
-  end
-
-  def average_miles_per_day
-    return unless can_estimate_mpd?
-
-    first_record = first_record_with_mileage
-    last_record = last_record_with_mileage
-
-    elapsed_mileage = last_record.mileage - first_record.mileage
-    elapsed_mileage / elapsed_days(last_record.date, first_record.date)
-  end
-
-  def elapsed_days(end_date, start_date)
-    ((end_date - start_date).to_i / 1.day).to_f
-  end
-
-  def can_estimate_mpd?
-    records.size >= 2 && first_record_with_mileage != last_record_with_mileage
-  end
-
-  def first_record_with_mileage
-    @first_record_with_mileage ||= records.where.not(mileage: nil).first
-  end
-
-  def last_record_with_mileage
-    @last_record_with_mileage ||= records.where('mileage > ?', 0).last
-  end
+  delegate :miles_per_year, to: :projection
 
   private
 
-  def weighted_average(values, weights)
-    sum = values.inject(:+).to_f
-    total_weight = weights.inject(:+).to_f
-
-    total_weight.nonzero? ? sum / total_weight : 0
+  def projection
+    @projection ||= MileageProjection.estimate(record_pairs, as_of: Time.zone.today)
   end
 
-  def round_to(value, int)
-    (value / int.to_f).round * int
+  def record_pairs
+    records.unscope(:order).where.not(mileage: nil)
+      .limit(MileageProjection::RECORD_LIMIT).order(date: :desc)
+      .pluck(:date, :mileage)
+      .map { |date, mileage| [date.to_date, mileage.to_f] }
   end
 end

--- a/api/app/services/mileage_projection.rb
+++ b/api/app/services/mileage_projection.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+class MileageProjection
+  RECORD_LIMIT = 10
+  ONE_YEAR = 365
+
+  Projection = Data.define(
+    :eligible?,
+    :estimated_mileage,
+    :miles_per_day,
+    :miles_per_year,
+    :estimated_next_record_date
+  )
+
+  def self.estimate(record_pairs, as_of:)
+    new(record_pairs, as_of:).estimate
+  end
+
+  def initialize(record_pairs, as_of:)
+    @pairs = record_pairs
+    @as_of = as_of.to_date
+  end
+
+  def estimate
+    Projection.new(
+      eligible?: eligible?,
+      estimated_mileage: estimated_mileage,
+      miles_per_day: eligible? ? calculated_miles_per_day : nil,
+      miles_per_year: miles_per_year_value,
+      estimated_next_record_date: estimated_next_record_date
+    )
+  end
+
+  private
+
+  attr_reader :pairs, :as_of
+
+  def eligible?
+    pairs.size >= 2
+  end
+
+  def estimated_mileage
+    unless eligible?
+      return if pairs.empty?
+
+      return pairs.first[1]
+    end
+
+    projected = round_to(estimated_mileage_exact, 50)
+    return estimated_mileage_exact.round(-1) unless projected > 50
+
+    projected
+  end
+
+  def estimated_mileage_exact
+    return unless eligible?
+
+    newest = pairs.first
+    (newest[1] + (calculated_miles_per_day * elapsed_days(as_of, newest[0]))).to_i
+  end
+
+  def estimated_next_record_date
+    return unless eligible?
+
+    newest = pairs.first
+    days = weighted_average_days_per_period + elapsed_days(as_of, newest[0])
+    newest[0] + days.days
+  end
+
+  def miles_per_year_value
+    return unless eligible?
+
+    projected = round_to(miles_per_year_exact, 500)
+    return miles_per_year_exact.round(-2) unless projected.positive?
+
+    projected
+  end
+
+  def miles_per_year_exact
+    return unless eligible?
+
+    (calculated_miles_per_day * ONE_YEAR).to_i
+  end
+
+  def calculated_miles_per_day
+    @calculated_miles_per_day ||= begin
+      mile_values = periods.pluck(:weighted_miles_per_day)
+      weight_values = periods.pluck(:weight)
+      weighted_average(mile_values, weight_values)
+    end
+  end
+
+  def weighted_average_days_per_period
+    day_values = periods.map { |p| p[:elapsed_days] * p[:weight] }
+    weight_values = periods.pluck(:weight)
+    weighted_average(day_values, weight_values)
+  end
+
+  def periods
+    @periods ||= pairs.each_with_index.filter_map do |pair, i|
+      previous = pairs[i + 1]
+      next unless previous
+
+      n = pairs.size - i
+      weight = n * (n - 1) / 2
+
+      period_elapsed_days = elapsed_days(pair[0], previous[0])
+      next if period_elapsed_days < 1
+
+      elapsed_miles = pair[1] - previous[1]
+
+      {
+        elapsed_days: period_elapsed_days,
+        elapsed_miles:,
+        miles_per_day: elapsed_miles / period_elapsed_days,
+        weight:,
+        weighted_miles_per_day: (elapsed_miles / period_elapsed_days) * weight
+      }
+    end
+  end
+
+  def elapsed_days(end_date, start_date)
+    (end_date - start_date).to_f
+  end
+
+  def weighted_average(values, weights)
+    sum = values.sum.to_f
+    total_weight = weights.sum.to_f
+    total_weight.nonzero? ? sum / total_weight : 0
+  end
+
+  def round_to(value, int)
+    (value / int.to_f).round * int
+  end
+end

--- a/api/test/services/mileage_projection_test.rb
+++ b/api/test/services/mileage_projection_test.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class MileageProjectionTest < ActiveSupport::TestCase
+  test 'eligible with two or more records' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert proj.eligible?
+  end
+
+  test 'not eligible with single record' do
+    pairs = [[Date.new(2026, 6, 1), 75_000]]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert_not proj.eligible?
+    assert_nil proj.miles_per_day
+    assert_nil proj.miles_per_year
+    assert_nil proj.estimated_next_record_date
+  end
+
+  test 'not eligible with empty pairs' do
+    proj = MileageProjection.estimate([], as_of: Date.new(2026, 7, 1))
+
+    assert_not proj.eligible?
+    assert_nil proj.estimated_mileage
+    assert_nil proj.miles_per_day
+  end
+
+  test 'estimated_mileage falls back to newest record when not eligible' do
+    pairs = [[Date.new(2026, 6, 1), 75_000]]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert_equal 75_000, proj.estimated_mileage
+  end
+
+  test 'estimated_mileage with two records' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    # 50k miles / 365 days = ~136.99 mpd
+    # projected from last record: 100000 + 0 days * 136.99 = 100000
+    assert_equal 100_000, proj.estimated_mileage
+  end
+
+  test 'projected mileage increases with elapsed time' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    # 30 days after last record: 100000 + (30 * 136.99) = ~104110
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 31))
+
+    assert proj.estimated_mileage > 100_000
+  end
+
+  test 'miles_per_day with two records' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert_in_delta 136.99, proj.miles_per_day, 0.01
+  end
+
+  test 'miles_per_year with two records' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    # 136.99 * 365 ≈ 50000, rounded to nearest 500
+    assert proj.miles_per_year.present?
+    assert proj.miles_per_year.positive?
+  end
+
+  test 'estimated_next_record_date' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000],
+      [Date.new(2024, 7, 1), 0]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert proj.estimated_next_record_date.present?
+    assert_kind_of Date, proj.estimated_next_record_date
+  end
+
+  test 'skips periods with zero elapsed days' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2026, 7, 1), 95_000],
+      [Date.new(2025, 1, 1), 0]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    # Should skip the 0-day interval and use the valid one
+    assert proj.eligible?
+    assert proj.miles_per_day.present?
+  end
+
+  test 'triangular weighting favors recent periods' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2026, 6, 1), 99_000], # recent: 1000 miles in 30 days
+      [Date.new(2025, 7, 1), 50_000] # old: 49000 miles in 335 days
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    # Triangular weighting favors recent period (33.3 mpd) over old (146.27 mpd),
+    # so weighted avg should be LOWER than simple avg
+    simple_avg = ((1000.0 / 30) + (49_000.0 / 335)) / 2
+    assert proj.miles_per_day < simple_avg,
+           "weighted avg (#{proj.miles_per_day}) should be below simple avg (#{simple_avg})"
+  end
+
+  test 'round_to helper' do
+    pairs = [
+      [Date.new(2026, 7, 1), 100_000],
+      [Date.new(2025, 7, 1), 50_000]
+    ]
+    proj = MileageProjection.estimate(pairs, as_of: Date.new(2026, 7, 1))
+
+    assert proj.eligible?
+  end
+end


### PR DESCRIPTION
Pull mileage computation out of Vehicle into a pure data-in, data-out module. Vehicle delegates through a single projection method. Mileage math becomes testable without AR.

- New `MileageProjection` module — pure math, `estimate(pairs, as_of:)`, returns `Projection` Data.define
- Vehicle — 4 delegates, 1 private query, -123 lines
- 12 tests — hardcoded arrays, no DB, 0 setup