### PR TITLE
Make notification channels injectable adapters

### DIFF
--- a/api/app/controllers/v2/webhooks_controller.rb
+++ b/api/app/controllers/v2/webhooks_controller.rb
@@ -6,10 +6,10 @@ module V2
       reminders = current_user.vehicles.flat_map(&:reminders).first(3)
 
       if reminders.any?
-        WebhookChannel.deliver(:reminder_today, user: current_user, reminders: reminders)
+        WebhookChannel.new.deliver(:reminder_today, user: current_user, reminders: reminders)
       else
         # Send a generic test even without reminders
-        WebhookChannel.deliver(:test, user: current_user, reminders: [])
+        WebhookChannel.new.deliver(:test, user: current_user, reminders: [])
       end
       render json: { message: 'Test notification sent' }, status: :ok
     end

--- a/api/app/jobs/daily_job.rb
+++ b/api/app/jobs/daily_job.rb
@@ -33,7 +33,7 @@ class DailyJob < ApplicationJob
         end
       end
 
-      NotificationDispatcher.dispatch(:reminder_upcoming, user: user, reminders: user_reminders)
+      NotificationDispatcher.new.dispatch(:reminder_upcoming, user: user, reminders: user_reminders)
       user.record_reminder_sent!
     end
   end
@@ -49,7 +49,7 @@ class DailyJob < ApplicationJob
     by_user.each do |user, user_schedules|
       next unless user.reminder_eligible?
 
-      NotificationDispatcher.dispatch(:schedule_due_upcoming, user: user, schedules: user_schedules)
+      NotificationDispatcher.new.dispatch(:schedule_due_upcoming, user: user, schedules: user_schedules)
     end
   end
 

--- a/api/app/jobs/hourly_job.rb
+++ b/api/app/jobs/hourly_job.rb
@@ -54,7 +54,7 @@ class HourlyJob < ApplicationJob
     end
     return if filtered.empty?
 
-    NotificationDispatcher.dispatch(:reminder_today, user: user, reminders: filtered)
+    NotificationDispatcher.new.dispatch(:reminder_today, user: user, reminders: filtered)
     user.record_reminder_sent!
   end
 
@@ -65,6 +65,6 @@ class HourlyJob < ApplicationJob
       .includes(:vehicle, :classification)
     return if schedules.empty?
 
-    NotificationDispatcher.dispatch(:schedule_due_today, user: user, schedules: schedules)
+    NotificationDispatcher.new.dispatch(:schedule_due_today, user: user, schedules: schedules)
   end
 end

--- a/api/app/services/channels/channel.rb
+++ b/api/app/services/channels/channel.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Channel
+  def can_deliver?(event, user)
+    available? && event_enabled?(event, user)
+  end
+
+  def deliver(event, user:, reminders: nil, schedules: nil)
+    raise NotImplementedError
+  end
+
+  private
+
+  def available?
+    raise NotImplementedError
+  end
+
+  def event_enabled?(_event, _user)
+    true
+  end
+end

--- a/api/app/services/channels/email_channel.rb
+++ b/api/app/services/channels/email_channel.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
-class EmailChannel
-  def self.available?
-    ENV['POSTMARK_API_KEY'].present? || ENV['SMTP_HOST'].present?
-  end
-
-  def self.deliver(event, user:, reminders: nil, schedules: nil)
+class EmailChannel < Channel
+  def deliver(event, user:, reminders: nil, schedules: nil)
     case event
     when :reminder_today
       RemindersMailer.reminder_today(user, reminders).deliver_now
@@ -18,8 +14,13 @@ class EmailChannel
     end
   end
 
-  def self.schedules_as_reminders(schedules)
+  private
+
+  def available?
+    ENV['POSTMARK_API_KEY'].present? || ENV['SMTP_HOST'].present?
+  end
+
+  def schedules_as_reminders(schedules)
     schedules.map { |s| ScheduleReminderAdapter.new(s) }
   end
-  private_class_method :schedules_as_reminders
 end

--- a/api/app/services/channels/webhook_channel.rb
+++ b/api/app/services/channels/webhook_channel.rb
@@ -2,14 +2,18 @@
 
 require 'net/http'
 
-class WebhookChannel
+class WebhookChannel < Channel
   TIMEOUT = 5
 
-  def self.available?
+  private
+
+  def available?
     true
   end
 
-  def self.deliver(event, user:, reminders: nil, schedules: nil)
+  public
+
+  def deliver(event, user:, reminders: nil, schedules: nil)
     webhook_url = user.preferences.webhook_url.presence
     return unless webhook_url
 
@@ -28,7 +32,9 @@ class WebhookChannel
     http.request(request)
   end
 
-  def self.build_payload(event, user, reminders: nil, schedules: nil)
+  private
+
+  def build_payload(event, user, reminders: nil, schedules: nil)
     payload = base_payload(event, user)
 
     if schedules
@@ -39,9 +45,8 @@ class WebhookChannel
 
     payload
   end
-  private_class_method :build_payload
 
-  def self.apply_ntfy_format(request, event, reminders: nil, schedules: nil)
+  def apply_ntfy_format(request, event, reminders: nil, schedules: nil)
     priority = event.to_s.start_with?('schedule') ? '4' : '3'
     title, message = ntfy_title_and_message(reminders:, schedules:)
 
@@ -51,26 +56,23 @@ class WebhookChannel
     request['Tags'] = 'wrench'
     request['Actions'] = "view, View Vehicles, #{Rails.application.config.x.web_url}/vehicles"
   end
-  private_class_method :apply_ntfy_format
 
-  def self.ntfy_title_and_message(reminders: nil, schedules: nil)
+  def ntfy_title_and_message(reminders: nil, schedules: nil)
     if schedules
       ntfy_schedules_content(schedules)
     else
       ntfy_reminders_content(Array(reminders))
     end
   end
-  private_class_method :ntfy_title_and_message
 
-  def self.ntfy_schedules_content(schedules)
+  def ntfy_schedules_content(schedules)
     names = schedules.map { |s| s.vehicle.name }.uniq
     title = "Schedules due for #{names.to_sentence}"
     message = schedules.map { |s| "#{s.vehicle.name}: #{s.classification.name}" }.join("\n")
     [title, message]
   end
-  private_class_method :ntfy_schedules_content
 
-  def self.ntfy_reminders_content(reminders)
+  def ntfy_reminders_content(reminders)
     names = reminders.map { |r| r.vehicle.name }.uniq
     title = "Reminders for #{names.to_sentence}"
     message = reminders.group_by(&:vehicle).map do |vehicle, veh_reminders|
@@ -78,23 +80,20 @@ class WebhookChannel
     end.join("\n\n")
     [title, message]
   end
-  private_class_method :ntfy_reminders_content
 
-  def self.vehicle_link(vehicle)
+  def vehicle_link(vehicle)
     "[#{vehicle.name}](#{Rails.application.config.x.web_url}/vehicles/#{vehicle.id})"
   end
-  private_class_method :vehicle_link
 
-  def self.base_payload(event, user)
+  def base_payload(event, user)
     {
       event: event,
       timestamp: Time.zone.now.iso8601,
       user: { email: user.email }
     }
   end
-  private_class_method :base_payload
 
-  def self.reminder_payload(reminder)
+  def reminder_payload(reminder)
     {
       notes: reminder.notes,
       vehicle: reminder.vehicle.name,
@@ -102,9 +101,8 @@ class WebhookChannel
       mileage: reminder.mileage
     }
   end
-  private_class_method :reminder_payload
 
-  def self.schedule_payload(schedule)
+  def schedule_payload(schedule)
     {
       classification: schedule.classification.name,
       vehicle: schedule.vehicle.name,
@@ -113,5 +111,4 @@ class WebhookChannel
       notes: schedule.notes
     }
   end
-  private_class_method :schedule_payload
 end

--- a/api/app/services/notification_dispatcher.rb
+++ b/api/app/services/notification_dispatcher.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
 class NotificationDispatcher
-  CHANNELS = [EmailChannel, WebhookChannel].freeze
+  DEFAULT_CHANNELS = [EmailChannel.new, WebhookChannel.new].freeze
 
-  def self.dispatch(event, **)
-    CHANNELS.each do |channel|
-      next unless channel.available?
+  def initialize(channels: DEFAULT_CHANNELS)
+    @channels = channels
+  end
 
-      channel.deliver(event, **)
+  def dispatch(event, **kwargs)
+    @channels.each do |channel|
+      next unless channel.can_deliver?(event, kwargs[:user])
+
+      channel.deliver(event, **kwargs)
     rescue StandardError => e
-      Rails.logger.error("#{channel}: #{e.message}")
+      Rails.logger.error("#{channel.class}: #{e.message}")
     end
   end
 end

--- a/api/test/services/notification_dispatcher_test.rb
+++ b/api/test/services/notification_dispatcher_test.rb
@@ -5,6 +5,28 @@ require 'test_helper'
 require 'webmock/minitest'
 require 'minitest/mock'
 
+class TestChannel < Channel
+  attr_reader :deliveries
+
+  def initialize
+    super
+    @deliveries = []
+    @available = true
+  end
+
+  def available?
+    @available
+  end
+
+  def disable!
+    @available = false
+  end
+
+  def deliver(event, user:, reminders: nil, schedules: nil)
+    @deliveries << { event:, user:, reminders:, schedules: }
+  end
+end
+
 class EmailChannelTest < ActiveSupport::TestCase
   setup do
     @user = User.first
@@ -27,43 +49,43 @@ class EmailChannelTest < ActiveSupport::TestCase
 
   test 'available? returns true when POSTMARK_API_KEY set' do
     with_env('POSTMARK_API_KEY' => 'key', 'SMTP_HOST' => nil) do
-      assert EmailChannel.available?
+      assert EmailChannel.new.can_deliver?(:reminder_today, @user)
     end
   end
 
   test 'available? returns true when SMTP_HOST set' do
     with_env('POSTMARK_API_KEY' => nil, 'SMTP_HOST' => 'smtp.example.com') do
-      assert EmailChannel.available?
+      assert EmailChannel.new.can_deliver?(:reminder_today, @user)
     end
   end
 
   test 'available? returns false when neither set' do
     with_env('POSTMARK_API_KEY' => nil, 'SMTP_HOST' => nil) do
-      assert_not EmailChannel.available?
+      assert_not EmailChannel.new.can_deliver?(:reminder_today, @user)
     end
   end
 
   test 'delivers reminder_today via RemindersMailer' do
     assert_emails 1 do
-      EmailChannel.deliver(:reminder_today, user: @user, reminders: @reminders)
+      EmailChannel.new.deliver(:reminder_today, user: @user, reminders: @reminders)
     end
   end
 
   test 'delivers reminder_upcoming via RemindersMailer' do
     assert_emails 1 do
-      EmailChannel.deliver(:reminder_upcoming, user: @user, reminders: @reminders)
+      EmailChannel.new.deliver(:reminder_upcoming, user: @user, reminders: @reminders)
     end
   end
 
   test 'delivers schedule_due_today via RemindersMailer' do
     assert_emails 1 do
-      EmailChannel.deliver(:schedule_due_today, user: @user, schedules: @schedules)
+      EmailChannel.new.deliver(:schedule_due_today, user: @user, schedules: @schedules)
     end
   end
 
   test 'delivers schedule_due_upcoming via RemindersMailer' do
     assert_emails 1 do
-      EmailChannel.deliver(:schedule_due_upcoming, user: @user, schedules: @schedules)
+      EmailChannel.new.deliver(:schedule_due_upcoming, user: @user, schedules: @schedules)
     end
   end
 
@@ -98,7 +120,7 @@ class WebhookChannelTest < ActiveSupport::TestCase
   end
 
   test 'available? returns true' do
-    assert WebhookChannel.available?
+    assert WebhookChannel.new.can_deliver?(:reminder_today, @user)
   end
 
   test 'sends reminder payload to webhook URL' do
@@ -106,7 +128,7 @@ class WebhookChannelTest < ActiveSupport::TestCase
     @user.save!
     stub_request(:post, 'https://hooks.example.com')
 
-    WebhookChannel.deliver(:reminder_today, user: @user, reminders: @reminders)
+    WebhookChannel.new.deliver(:reminder_today, user: @user, reminders: @reminders)
 
     assert_requested(:post, 'https://hooks.example.com') do |req|
       body = JSON.parse(req.body)
@@ -121,7 +143,7 @@ class WebhookChannelTest < ActiveSupport::TestCase
     @user.save!
     stub_request(:post, 'https://hooks.example.com')
 
-    WebhookChannel.deliver(:schedule_due_today, user: @user, schedules: [@schedule])
+    WebhookChannel.new.deliver(:schedule_due_today, user: @user, schedules: [@schedule])
 
     assert_requested(:post, 'https://hooks.example.com') do |req|
       body = JSON.parse(req.body)
@@ -129,16 +151,6 @@ class WebhookChannelTest < ActiveSupport::TestCase
         body.key?('schedules') &&
         !body.key?('reminders')
     end
-  end
-
-  private
-
-  def with_env(vars)
-    originals = vars.to_h { |k, _| [k.to_s, ENV.fetch(k.to_s, nil)] }
-    vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
-    yield
-  ensure
-    originals.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
   end
 end
 
@@ -148,80 +160,70 @@ class NotificationDispatcherTest < ActiveSupport::TestCase
     @reminders = @user.reminders.to_a
   end
 
-  test 'dispatches to email channel when available' do
-    EmailChannel.stub(:available?, true) do
-      WebhookChannel.stub(:available?, false) do
-        assert_emails 1 do
-          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
-        end
-      end
-    end
-  end
+  test 'dispatches to available channels' do
+    channel = TestChannel.new
+    dispatcher = NotificationDispatcher.new(channels: [channel])
 
-  test 'dispatches to webhook channel when available' do
-    @user.preferences.webhook_url = 'https://hooks.example.com'
-    @user.save!
-    stub_request(:post, 'https://hooks.example.com')
+    dispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
 
-    EmailChannel.stub(:available?, false) do
-      WebhookChannel.stub(:available?, true) do
-        NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
-      end
-    end
-
-    assert_requested :post, 'https://hooks.example.com'
-  end
-
-  test 'dispatches to both channels when both available' do
-    @user.preferences.webhook_url = 'https://hooks.example.com'
-    @user.save!
-    stub_request(:post, 'https://hooks.example.com')
-
-    EmailChannel.stub(:available?, true) do
-      WebhookChannel.stub(:available?, true) do
-        assert_emails 1 do
-          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
-        end
-      end
-    end
-
-    assert_requested :post, 'https://hooks.example.com'
+    assert_equal 1, channel.deliveries.size
+    assert_equal :reminder_today, channel.deliveries.first[:event]
   end
 
   test 'skips unavailable channels' do
-    EmailChannel.stub(:available?, false) do
-      WebhookChannel.stub(:available?, false) do
-        assert_emails 0 do
-          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
-        end
-      end
-    end
+    channel = TestChannel.new
+    channel.disable!
+    dispatcher = NotificationDispatcher.new(channels: [channel])
+
+    dispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+
+    assert_empty channel.deliveries
+  end
+
+  test 'dispatches to all available channels' do
+    channel_a = TestChannel.new
+    channel_b = TestChannel.new
+    dispatcher = NotificationDispatcher.new(channels: [channel_a, channel_b])
+
+    dispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+
+    assert_equal 1, channel_a.deliveries.size
+    assert_equal 1, channel_b.deliveries.size
+  end
+
+  test 'skips unavailable but delivers to available' do
+    channel_a = TestChannel.new
+    channel_b = TestChannel.new
+    channel_b.disable!
+    dispatcher = NotificationDispatcher.new(channels: [channel_a, channel_b])
+
+    dispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
+
+    assert_equal 1, channel_a.deliveries.size
+    assert_empty channel_b.deliveries
   end
 
   test 'continues to next channel if one raises' do
-    @user.preferences.webhook_url = 'https://hooks.example.com'
-    @user.save!
-    stub_request(:post, 'https://hooks.example.com')
+    channel_a = TestChannel.new
+    # Inject a channel that redefines deliver to raise
+    failing = Class.new(Channel) do
+      define_method(:available?) { true }
+      define_method(:deliver) { |*| raise 'down' }
+    end.new
+    dispatcher = NotificationDispatcher.new(channels: [failing, channel_a])
 
-    EmailChannel.stub(:available?, true) do
-      WebhookChannel.stub(:available?, true) do
-        # Stub deliver to raise, then verify webhook still fires
-        EmailChannel.stub(:deliver, ->(*, **) { raise 'email down' }) do
-          NotificationDispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
-        end
-      end
-    end
+    dispatcher.dispatch(:reminder_today, user: @user, reminders: @reminders)
 
-    assert_requested :post, 'https://hooks.example.com'
+    assert_equal 1, channel_a.deliveries.size
   end
 
-  private
+  test 'delivers with user and event context' do
+    channel = TestChannel.new
+    dispatcher = NotificationDispatcher.new(channels: [channel])
 
-  def with_env(vars)
-    originals = vars.transform_keys(&:to_s).transform_values { |k| ENV.fetch(k, nil) }
-    vars.each { |k, v| v.nil? ? ENV.delete(k.to_s) : ENV[k.to_s] = v }
-    yield
-  ensure
-    originals.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    dispatcher.dispatch(:schedule_due_upcoming, user: @user, schedules: [])
+
+    assert_equal :schedule_due_upcoming, channel.deliveries.first[:event]
+    assert_equal @user, channel.deliveries.first[:user]
   end
 end


### PR DESCRIPTION
Replace class-method channels and dispatcher with injectable instances.

- New `Channel` base class with `can_deliver?(event, user)`
- `EmailChannel` and `WebhookChannel` inherit `Channel`, use instance methods
- `NotificationDispatcher` accepts channels via `initialize(channels:)`, default from `DEFAULT_CHANNELS`
- Jobs call `NotificationDispatcher.new.dispatch(...)`, webhooks controller calls `WebhookChannel.new.deliver(...)`
- `TestChannel` replaces class-method stubbing with delivery recording